### PR TITLE
Share recovery and refreshing

### DIFF
--- a/tpke/benches/benchmarks.rs
+++ b/tpke/benches/benchmarks.rs
@@ -1,5 +1,11 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ark_std::Zero;
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
+};
 use group_threshold_cryptography::*;
+
+type Fr = <ark_bls12_381::Bls12_381 as ark_ec::PairingEngine>::Fr;
+type E = ark_bls12_381::Bls12_381;
 
 pub fn bench_decryption(c: &mut Criterion) {
     use rand::SeedableRng;
@@ -143,5 +149,49 @@ pub fn bench_decryption(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_decryption);
+pub fn bench_random_poly(c: &mut Criterion) {
+    use rand::SeedableRng;
+    let mut group = c.benchmark_group("RandomPoly");
+    group.sample_size(10);
+
+    for threshold in [1, 2, 4, 8, 16, 32, 64] {
+        let rng = &mut rand::rngs::StdRng::seed_from_u64(0);
+        let mut ark = {
+            let mut rng = rng.clone();
+            move || {
+                black_box(make_random_ark_polynomial_at::<E>(
+                    threshold,
+                    &Fr::zero(),
+                    &mut rng,
+                ))
+            }
+        };
+        let mut vec = {
+            let mut rng = rng.clone();
+            move || {
+                black_box(make_random_polynomial_at::<E>(
+                    threshold,
+                    &Fr::zero(),
+                    &mut rng,
+                ))
+            }
+        };
+        group.bench_function(
+            BenchmarkId::new("random_polynomial_ark", threshold),
+            |b| {
+                #[allow(clippy::redundant_closure)]
+                b.iter(|| ark())
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("random_polynomial_vec", threshold),
+            |b| {
+                #[allow(clippy::redundant_closure)]
+                b.iter(|| vec())
+            },
+        );
+    }
+}
+
+criterion_group!(benches, bench_decryption, bench_random_poly);
 criterion_main!(benches);

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -3,7 +3,6 @@
 
 use crate::*;
 use ark_ec::ProjectiveCurve;
-use itertools::zip_eq;
 
 pub fn prepare_combine_fast<E: PairingEngine>(
     public_decryption_contexts: &[PublicDecryptionContextFast<E>],
@@ -61,17 +60,27 @@ fn lagrange_coeffs_at<E: PairingEngine>(
     x_i: &E::Fr,
 ) -> Vec<E::Fr> {
     // Calculate lagrange coefficients using optimized formula, see https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
-    let mut lagrange_coeffs = vec![];
-    for x_j in shares_x {
-        let mut prod = E::Fr::one();
-        for x_m in shares_x {
-            if x_j != x_m {
-                prod *= (*x_m - x_i) / (*x_m - *x_j);
-            }
-        }
-        lagrange_coeffs.push(prod);
-    }
-    lagrange_coeffs
+    // In this formula x_i = 0, hence numerator is x_m
+    lagrange_basis_at::<E>(shares_x, &E::Fr::zero())
+}
+
+/// Calculates Lagrange coefficients for a given x_i
+pub fn lagrange_basis_at<E: PairingEngine>(
+    shares_x: &[E::Fr],
+    x_i: &E::Fr,
+) -> Vec<E::Fr> {
+    shares_x
+        .iter()
+        .map(|x_j| {
+            let mut prod = E::Fr::one();
+            shares_x.iter().for_each(|x_m| {
+                if x_j != x_m {
+                    prod *= (*x_m - x_i) / (*x_m - *x_j);
+                }
+            });
+            prod
+        })
+        .collect()
 }
 
 pub fn share_combine_fast<E: PairingEngine>(
@@ -101,7 +110,7 @@ pub fn share_combine_simple<E: PairingEngine>(
     let mut product_of_shares = E::Fqk::one();
 
     // Sum of C_i^{L_i}z
-    for (c_i, alpha_i) in zip_eq(shares.iter(), lagrange_coeffs.iter()) {
+    for (c_i, alpha_i) in izip!(shares, lagrange_coeffs) {
         // Exponentiation by alpha_i
         let ss = c_i.pow(alpha_i.into_repr());
         product_of_shares *= ss;

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -51,17 +51,9 @@ pub fn prepare_combine_simple<E: PairingEngine>(
         .map(|ctxt| ctxt.domain)
         .collect::<Vec<_>>();
 
-    // In this formula x_i = 0, hence numerator is x_m
-    lagrange_coeffs_at::<E>(&shares_x, &E::Fr::zero())
-}
-
-fn lagrange_coeffs_at<E: PairingEngine>(
-    shares_x: &Vec<E::Fr>,
-    x_i: &E::Fr,
-) -> Vec<E::Fr> {
     // Calculate lagrange coefficients using optimized formula, see https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
     // In this formula x_i = 0, hence numerator is x_m
-    lagrange_basis_at::<E>(shares_x, &E::Fr::zero())
+    lagrange_basis_at::<E>(&shares_x, &E::Fr::zero())
 }
 
 /// Calculates Lagrange coefficients for a given x_i

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -23,6 +23,7 @@ pub struct SetupParams<E: PairingEngine> {
     pub g: E::G1Affine,
     pub g_inv: E::G1Prepared,
     pub h_inv: E::G2Prepared,
+    pub h: E::G2Affine,
 }
 
 #[derive(Clone, Debug)]

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -291,6 +291,11 @@ pub fn setup_simple<E: PairingEngine>(
         private.public_decryption_contexts = public_contexts.clone();
     }
 
+    // TODO: Should we also be returning some sort of signed transcript?
+    // "Post the signed message \(\tau, (F_0, \ldots, F_t), \hat{u}2, (\hat{Y}{i,\omega_j})\) to the blockchain"
+    // \tau - unique session identifier
+    // See: https://nikkolasg.github.io/ferveo/pvss.html#dealers-role
+
     (pubkey.into(), privkey.into(), private_contexts)
 }
 

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -177,6 +177,7 @@ pub fn setup_fast<E: PairingEngine>(
                 g,
                 g_inv: E::G1Prepared::from(-g),
                 h_inv: E::G2Prepared::from(-h),
+                h,
             },
             private_key_share,
             public_decryption_contexts: vec![],
@@ -272,6 +273,7 @@ pub fn setup_simple<E: PairingEngine>(
                 g,
                 g_inv: E::G1Prepared::from(-g),
                 h_inv: E::G2Prepared::from(-h),
+                h,
             },
             private_key_share,
             public_decryption_contexts: vec![],
@@ -332,8 +334,7 @@ mod tests {
         let msg: &[u8] = "abc".as_bytes();
         let aad: &[u8] = "my-aad".as_bytes();
 
-        let (pubkey, _, _) =
-            setup_fast::<E>(threshold, shares_num, rng);
+        let (pubkey, _, _) = setup_fast::<E>(threshold, shares_num, rng);
 
         let ciphertext = encrypt::<StdRng, E>(msg, aad, &pubkey, rng);
 
@@ -365,8 +366,7 @@ mod tests {
         let msg: &[u8] = "abc".as_bytes();
         let aad: &[u8] = "my-aad".as_bytes();
 
-        let (pubkey, privkey, _) =
-            setup_fast::<E>(threshold, shares_num, rng);
+        let (pubkey, privkey, _) = setup_fast::<E>(threshold, shares_num, rng);
 
         let ciphertext = encrypt::<StdRng, E>(msg, aad, &pubkey, rng);
         let plaintext = checked_decrypt(&ciphertext, aad, privkey);
@@ -433,8 +433,7 @@ mod tests {
         let msg: &[u8] = "abc".as_bytes();
         let aad: &[u8] = "my-aad".as_bytes();
 
-        let (pubkey, _, _) =
-            setup_fast::<E>(threshold, shares_num, rng);
+        let (pubkey, _, _) = setup_fast::<E>(threshold, shares_num, rng);
         let mut ciphertext = encrypt::<StdRng, E>(msg, aad, &pubkey, rng);
 
         // So far, the ciphertext is valid
@@ -470,8 +469,7 @@ mod tests {
                 make_decryption_share(&ctxt.private_key_share, &ciphertext)
             })
             .collect();
-        let pub_contexts =
-            &contexts[0].public_decryption_contexts;
+        let pub_contexts = &contexts[0].public_decryption_contexts;
         let lagrange = prepare_combine_simple::<E>(pub_contexts);
 
         let shared_secret =
@@ -559,11 +557,7 @@ mod tests {
         pub_contexts: &[PublicDecryptionContextSimple<E>],
         decryption_shares: &[E::Fqk],
     ) -> E::Fqk {
-        let shares_x = pub_contexts
-            .iter()
-            .map(|context| context.domain)
-            .collect::<Vec<_>>();
-        let lagrange = prepare_combine_simple::<E>(&shares_x);
+        let lagrange = prepare_combine_simple::<E>(pub_contexts);
         share_combine_simple::<E>(decryption_shares, &lagrange)
     }
 

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -457,7 +457,7 @@ mod tests {
         let msg: &[u8] = "abc".as_bytes();
         let aad: &[u8] = "my-aad".as_bytes();
 
-        let (pubkey, _, private_decryption_contexts) =
+        let (pubkey, _, contexts) =
             setup_simple::<E>(threshold, shares_num, rng);
 
         // Ciphertext.commitment is already computed to match U

--- a/tpke/src/refresh.rs
+++ b/tpke/src/refresh.rs
@@ -128,7 +128,7 @@ fn prepare_share_updates_for_refreshing<E: PairingEngine>(
 
 fn compute_polynomial_deltas<E: PairingEngine>(
     participants: &[PrivateDecryptionContextSimple<E>],
-    coeffs: &Vec<E::Fr>,
+    coeffs: &[E::Fr],
 ) -> HashMap<usize, E::G2Projective> {
     participants
         .iter()

--- a/tpke/src/refresh.rs
+++ b/tpke/src/refresh.rs
@@ -1,0 +1,125 @@
+use crate::{lagrange_basis_at, PrivateDecryptionContextSimple};
+use ark_ec::{PairingEngine, ProjectiveCurve};
+use ark_ff::{One, PrimeField, Zero};
+use ark_std::UniformRand;
+use itertools::zip_eq;
+use rand::prelude::StdRng;
+use rand_core::RngCore;
+use std::collections::HashMap;
+use std::usize;
+
+pub fn recover_share_at_point<E: PairingEngine>(
+    other_participants: &[PrivateDecryptionContextSimple<E>],
+    threshold: usize,
+    x_r: &E::Fr,
+    rng: &mut StdRng,
+) -> E::G2Projective {
+    let share_updates =
+        prepare_share_updates::<E>(other_participants, x_r, threshold, rng);
+
+    let new_shares_y =
+        update_decryption_shares::<E>(other_participants, &share_updates);
+
+    // Interpolate new shares to recover y_r
+    let shares_x = &other_participants[0]
+        .public_decryption_contexts
+        .iter()
+        .map(|ctxt| ctxt.domain)
+        .collect::<Vec<_>>();
+
+    // Recover y_r
+    let lagrange = lagrange_basis_at::<E>(shares_x, x_r);
+    let prods =
+        zip_eq(new_shares_y, lagrange).map(|(y_j, l)| y_j.mul(l.into_repr()));
+    prods.fold(E::G2Projective::zero(), |acc, y_j| acc + y_j)
+}
+
+fn prepare_share_updates<E: PairingEngine>(
+    participants: &[PrivateDecryptionContextSimple<E>],
+    x_r: &E::Fr,
+    threshold: usize,
+    rng: &mut impl RngCore,
+) -> HashMap<usize, HashMap<usize, E::G2Projective>> {
+    // TODO: Refactor this function so that each participant performs it individually
+    // Each participant prepares an update for each other participant
+    participants
+        .iter()
+        .map(|p1| {
+            let i = p1.index;
+            // Generate a new random polynomial with constant term 0
+            let d_i = make_random_polynomial::<E>(threshold, x_r, rng);
+
+            // Now, we need to evaluate the polynomial at each of participants' indices
+            let deltas_i: HashMap<_, _> = participants
+                .iter()
+                .map(|p2| {
+                    let j = p2.index;
+                    let x_j = p2.public_decryption_contexts[j].domain;
+                    // Compute the evaluation of the polynomial at the domain element x_j
+                    // d_i(x_j)
+                    let eval = evaluate_polynomial::<E>(&d_i, &x_j);
+                    let h_g2 = E::G2Projective::from(p2.h);
+                    let eval_g2 = h_g2.mul(eval.into_repr());
+                    (j, eval_g2)
+                })
+                .collect();
+            (i, deltas_i)
+        })
+        .collect::<HashMap<_, _>>()
+}
+
+fn update_decryption_shares<E: PairingEngine>(
+    participants: &[PrivateDecryptionContextSimple<E>],
+    deltas: &HashMap<usize, HashMap<usize, E::G2Projective>>,
+) -> Vec<E::G2Projective> {
+    // TODO: Refactor this function so that each participant performs it individually
+    participants
+        .iter()
+        .map(|p| {
+            let i = p.index;
+            let mut new_y = E::G2Projective::from(
+                p.private_key_share.private_key_shares[0], // y_i
+            );
+            for j in deltas.keys() {
+                new_y += deltas[j][&i];
+            }
+            new_y
+        })
+        .collect()
+}
+
+fn make_random_polynomial<E: PairingEngine>(
+    threshold: usize,
+    x_r: &E::Fr,
+    rng: &mut impl RngCore,
+) -> Vec<E::Fr> {
+    // [][threshold-1]
+    let mut d_i = (0..threshold - 1)
+        .map(|_| E::Fr::rand(rng))
+        .collect::<Vec<_>>();
+    // [0..][threshold]
+    d_i.insert(0, E::Fr::zero());
+
+    // Now, we calculate d_i_0
+    // This is the term that will "zero out" the polynomial at x_r, d_i(x_r) = 0
+    let d_i_0 = E::Fr::zero() - evaluate_polynomial::<E>(&d_i, x_r);
+    d_i[0] = d_i_0;
+    assert_eq!(evaluate_polynomial::<E>(&d_i, x_r), E::Fr::zero());
+
+    assert_eq!(d_i.len(), threshold);
+
+    d_i
+}
+
+fn evaluate_polynomial<E: PairingEngine>(
+    polynomial: &[E::Fr],
+    x: &E::Fr,
+) -> E::Fr {
+    let mut result = E::Fr::zero();
+    let mut x_power = E::Fr::one();
+    for coeff in polynomial {
+        result += *coeff * x_power;
+        x_power *= x;
+    }
+    result
+}

--- a/tpke/src/refresh.rs
+++ b/tpke/src/refresh.rs
@@ -1,8 +1,7 @@
 use crate::{lagrange_basis_at, PrivateDecryptionContextSimple};
 use ark_ec::{PairingEngine, ProjectiveCurve};
 use ark_ff::{PrimeField, Zero};
-use ark_poly::univariate::DensePolynomial;
-use ark_poly::{Polynomial, UVPolynomial};
+use ark_poly::{univariate::DensePolynomial, Polynomial, UVPolynomial};
 use ark_std::UniformRand;
 use itertools::zip_eq;
 use rand::prelude::StdRng;
@@ -86,7 +85,7 @@ fn update_shares_for_recovery<E: PairingEngine>(
         .collect()
 }
 
-fn make_random_polynomial_at<E: PairingEngine>(
+pub fn make_random_polynomial_at<E: PairingEngine>(
     threshold: usize,
     root: &E::Fr,
     rng: &mut impl RngCore,
@@ -108,6 +107,20 @@ fn make_random_polynomial_at<E: PairingEngine>(
     debug_assert!(d_i.len() == threshold);
 
     d_i
+}
+
+pub fn make_random_ark_polynomial_at<E: PairingEngine>(
+    threshold: usize,
+    root: &E::Fr,
+    rng: &mut impl RngCore,
+) -> Vec<E::Fr> {
+    let mut threshold_poly = DensePolynomial::<E::Fr>::rand(threshold - 1, rng);
+    threshold_poly[0] = E::Fr::zero();
+    let d_i_0 = E::Fr::zero() - threshold_poly.evaluate(root);
+    threshold_poly[0] = d_i_0;
+    debug_assert!(threshold_poly.evaluate(root) == E::Fr::zero());
+    debug_assert!(threshold_poly.coeffs.len() == threshold);
+    threshold_poly.coeffs
 }
 
 fn prepare_share_updates_for_refreshing<E: PairingEngine>(

--- a/tpke/src/refresh.rs
+++ b/tpke/src/refresh.rs
@@ -124,7 +124,7 @@ fn compute_polynomial_deltas<E: PairingEngine>(
     participants: &[PrivateDecryptionContextSimple<E>],
     polynomial: &DensePolynomial<E::Fr>,
 ) -> HashMap<usize, E::G2Projective> {
-    let h_g2 = E::G2Projective::from(participants[0].h);
+    let h_g2 = E::G2Projective::from(participants[0].setup_params.h);
     participants
         .iter()
         .map(|p| {

--- a/tpke/src/refresh.rs
+++ b/tpke/src/refresh.rs
@@ -1,6 +1,8 @@
 use crate::{lagrange_basis_at, PrivateDecryptionContextSimple};
 use ark_ec::{PairingEngine, ProjectiveCurve};
-use ark_ff::{One, PrimeField, Zero};
+use ark_ff::{PrimeField, Zero};
+use ark_poly::univariate::DensePolynomial;
+use ark_poly::{Polynomial, UVPolynomial};
 use ark_std::UniformRand;
 use itertools::zip_eq;
 use rand::prelude::StdRng;
@@ -39,14 +41,13 @@ pub fn recover_share_at_point<E: PairingEngine>(
     prods.fold(E::G2Projective::zero(), |acc, y_j| acc + y_j)
 }
 
+/// From PSS paper, section 4.2.1, (https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf)
 fn prepare_share_updates_for_recovery<E: PairingEngine>(
     participants: &[PrivateDecryptionContextSimple<E>],
     x_r: &E::Fr,
     threshold: usize,
     rng: &mut impl RngCore,
 ) -> HashMap<usize, HashMap<usize, E::G2Projective>> {
-    // From PSS paper, section 4.2.1, (https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf)
-
     // TODO: Refactor this function so that each participant performs it individually
     // Each participant prepares an update for each other participant
     participants
@@ -64,11 +65,11 @@ fn prepare_share_updates_for_recovery<E: PairingEngine>(
         .collect::<HashMap<_, _>>()
 }
 
+/// From PSS paper, section 4.2.3, (https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf)
 fn update_shares_for_recovery<E: PairingEngine>(
     participants: &[PrivateDecryptionContextSimple<E>],
     deltas: &HashMap<usize, HashMap<usize, E::G2Projective>>,
 ) -> Vec<E::G2Projective> {
-    // From PSS paper, section 4.2.3, (https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf)
     // TODO: Refactor this function so that each participant performs it individually
     participants
         .iter()
@@ -89,36 +90,24 @@ fn make_random_polynomial_at<E: PairingEngine>(
     threshold: usize,
     root: &E::Fr,
     rng: &mut impl RngCore,
-) -> Vec<E::Fr> {
+) -> DensePolynomial<E::Fr> {
     // [][threshold-1]
     let mut d_i = (0..threshold - 1)
         .map(|_| E::Fr::rand(rng))
         .collect::<Vec<_>>();
     // [0..][threshold]
     d_i.insert(0, E::Fr::zero());
+    let mut d_i = DensePolynomial::from_coefficients_vec(d_i);
 
     // Now, we calculate d_i_0
     // This is the term that will "zero out" the polynomial at x_r, d_i(x_r) = 0
-    let d_i_0 = E::Fr::zero() - evaluate_polynomial::<E>(&d_i, root);
+    let d_i_0 = E::Fr::zero() - d_i.evaluate(root);
     d_i[0] = d_i_0;
-    assert_eq!(evaluate_polynomial::<E>(&d_i, root), E::Fr::zero());
 
-    assert_eq!(d_i.len(), threshold);
+    debug_assert!(d_i.evaluate(root) == E::Fr::zero());
+    debug_assert!(d_i.len() == threshold);
 
     d_i
-}
-
-fn evaluate_polynomial<E: PairingEngine>(
-    polynomial: &[E::Fr],
-    x: &E::Fr,
-) -> E::Fr {
-    let mut result = E::Fr::zero();
-    let mut x_power = E::Fr::one();
-    for coeff in polynomial {
-        result += *coeff * x_power;
-        x_power *= x;
-    }
-    result
 }
 
 fn prepare_share_updates_for_refreshing<E: PairingEngine>(
@@ -126,21 +115,22 @@ fn prepare_share_updates_for_refreshing<E: PairingEngine>(
     threshold: usize,
     rng: &mut impl RngCore,
 ) -> HashMap<usize, E::G2Projective> {
-    let coeffs = make_random_polynomial_at::<E>(threshold, &E::Fr::zero(), rng);
-    compute_polynomial_deltas(participants, &coeffs)
+    let polynomial =
+        make_random_polynomial_at::<E>(threshold, &E::Fr::zero(), rng);
+    compute_polynomial_deltas(participants, &polynomial)
 }
 
 fn compute_polynomial_deltas<E: PairingEngine>(
     participants: &[PrivateDecryptionContextSimple<E>],
-    coeffs: &[E::Fr],
+    polynomial: &DensePolynomial<E::Fr>,
 ) -> HashMap<usize, E::G2Projective> {
+    let h_g2 = E::G2Projective::from(participants[0].h);
     participants
         .iter()
         .map(|p| {
             let i = p.index;
             let x_i = p.public_decryption_contexts[i].domain;
-            let eval = evaluate_polynomial::<E>(coeffs, &x_i);
-            let h_g2 = E::G2Projective::from(p.h);
+            let eval = polynomial.evaluate(&x_i);
             let eval_g2 = h_g2.mul(eval.into_repr());
             (i, eval_g2)
         })


### PR DESCRIPTION
- Based on #20 
  -  Please review parent PR first
  - Already rebased
- Closes #3
- Implement share refreshing and share recovery, or "PSS" (Proactive Secret Sharing)
  - For the description of share refreshing, see this [abbreviated algorithm](https://www.wikiwand.com/en/Proactive_secret_sharing#Mathematics)
  - For the description of share recovery, see section 4.2 of the [PSS paper](https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf) 	
- How to review this PR:
  - This PR adds three tests in `tpke/src/lib.rs` that contain three different PSS flows:
    - `simple_threshold_decryption_with_share_refreshing_at_point` - refreshes a key share knowing the evaluation point of a selected PSS participant
    -  `simple_threshold_decryption_with_share_recovery_at_point` - recovers a key share with no knowledge of the evaluation point of a selected participant. Effectively, we generate a new key share for a new participant. Uses the same implementation as the previous test (section 4.2) 
    - `simple_threshold_decryption_with_share_refresh` - refreshes all key shares for all existing participants. Uses a slightly different approach than the previous implementations
  - You should start by reading the tests and inspecting function calls one by one
  - Code specific to PSS is placed in `tpke/src/refresh.rs`
  - Other changes are largely irrelevant (code refactoring, comments, todos, etc.)