### PR TITLE
Implement a simple threshold decryption subvariant

### DIFF
--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -46,7 +46,7 @@ version = "0.10.0"
 features = ["alloc"]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3" # supports pprof, # TODO: Figure out if/how we can update to 0.4
 pprof = { version = "0.6", features = ["flamegraph", "criterion"] }
 
 [[example]]

--- a/tpke-wasm/benches/benchmarks.rs
+++ b/tpke-wasm/benches/benchmarks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::redundant_closure)]
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 pub fn bench_encrypt_combine(c: &mut Criterion) {
@@ -55,14 +57,12 @@ pub fn bench_encrypt_combine(c: &mut Criterion) {
         let encrypt_fn = bench_encrypt(*num_shares, *num_shares);
         group.measurement_time(core::time::Duration::new(45, 0));
         group.bench_function(format!("tpke-wasm::encrypt - num_shares={}, num_entities={}, threshold={}", num_shares, num_shares, num_shares), |b| {
-            #[allow(clippy::redundant_closure)]
             b.iter(|| encrypt_fn())
         });
 
         let combine_fn = bench_combine(*num_shares, *num_shares);
         group.measurement_time(core::time::Duration::new(45, 0));
         group.bench_function(format!("tpke-wasm::combine - num_shares={}, num_entities={}, threshold={}", num_shares, num_shares, num_shares), |b| {
-            #[allow(clippy::redundant_closure)]
             b.iter(|| combine_fn())
         });
     }

--- a/tpke/benches/arkworks.rs
+++ b/tpke/benches/arkworks.rs
@@ -265,17 +265,11 @@ pub fn bench_random_poly(c: &mut Criterion) {
         };
         group.bench_function(
             BenchmarkId::new("random_polynomial_ark", threshold),
-            |b| {
-                #[allow(clippy::redundant_closure)]
-                b.iter(|| ark())
-            },
+            |b| b.iter(|| ark()),
         );
         group.bench_function(
             BenchmarkId::new("random_polynomial_naive", threshold),
-            |b| {
-                #[allow(clippy::redundant_closure)]
-                b.iter(|| naive())
-            },
+            |b| b.iter(|| naive()),
         );
     }
 }

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -57,9 +57,6 @@ impl SetupFast {
         let prepared_key_shares =
             prepare_combine_fast(&pub_contexts, &decryption_shares);
 
-        let _shared_secret =
-            share_combine_fast(&decryption_shares, &prepared_key_shares);
-
         let shared_secret =
             share_combine_fast(&decryption_shares, &prepared_key_shares);
 
@@ -203,10 +200,7 @@ pub fn bench_create_decryption_share(c: &mut Criterion) {
         );
         group.bench_function(
             BenchmarkId::new("share_create_simple_precomputed", shares_num),
-            |b| {
-                #[allow(clippy::redundant_closure)]
-                b.iter(|| simple_precomputed())
-            },
+            |b| b.iter(|| simple_precomputed()),
         );
     }
 }
@@ -305,10 +299,7 @@ pub fn bench_share_combine(c: &mut Criterion) {
         );
         group.bench_function(
             BenchmarkId::new("share_combine_simple_precomputed", shares_num),
-            |b| {
-                #[allow(clippy::redundant_closure)]
-                b.iter(|| simple_precomputed())
-            },
+            |b| b.iter(|| simple_precomputed()),
         );
     }
 }

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -175,7 +175,7 @@ pub fn bench_create_decryption_share(c: &mut Criterion) {
             }
         };
         let simple_precomputed = {
-            let setup = SetupSimple::new(shares_num, rng);
+            let setup = SetupSimple::new(shares_num, MSG_SIZE_CASES[0], rng);
             move || {
                 black_box(
                     setup
@@ -274,7 +274,7 @@ pub fn bench_share_combine(c: &mut Criterion) {
             }
         };
         let simple_precomputed = {
-            let setup = SetupSimple::new(shares_num, rng);
+            let setup = SetupSimple::new(shares_num, MSG_SIZE_CASES[0], rng);
 
             let decryption_shares: Vec<_> = setup
                 .contexts

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -99,7 +99,7 @@ pub fn share_combine_simple<E: PairingEngine>(
 pub fn share_combine_simple_precomputed<E: PairingEngine>(
     shares: &[DecryptionShareSimplePrecomputed<E>],
 ) -> E::Fqk {
-    // TODO: Add formulas
+    // $s = ∏C_{λ_i}$, where $λ_i$ is the Lagrange coefficient for $i$.
     shares
         .iter()
         .fold(E::Fqk::one(), |acc, c_i| acc * c_i.decryption_share)

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -96,6 +96,15 @@ pub fn share_combine_simple<E: PairingEngine>(
     product_of_shares
 }
 
+pub fn share_combine_simple_precomputed<E: PairingEngine>(
+    shares: &[DecryptionShareSimplePrecomputed<E>],
+) -> E::Fqk {
+    // TODO: Add formulas
+    shares
+        .iter()
+        .fold(E::Fqk::one(), |acc, c_i| acc * c_i.decryption_share)
+}
+
 #[cfg(test)]
 mod tests {
     type Fr = <ark_bls12_381::Bls12_381 as ark_ec::PairingEngine>::Fr;

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -35,14 +35,12 @@ pub fn prepare_combine_fast<E: PairingEngine>(
 pub fn prepare_combine_simple<E: PairingEngine>(
     domain: &[E::Fr],
 ) -> Vec<E::Fr> {
-    // See https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
     // In this formula x_i = 0, hence numerator is x_m
     // See https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
     lagrange_basis_at::<E>(domain, &E::Fr::zero())
 }
 
 /// Calculate lagrange coefficients using optimized formula
-/// See https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
 pub fn lagrange_basis_at<E: PairingEngine>(
     shares_x: &[E::Fr],
     x_i: &E::Fr,
@@ -99,7 +97,7 @@ pub fn share_combine_simple<E: PairingEngine>(
 pub fn share_combine_simple_precomputed<E: PairingEngine>(
     shares: &[DecryptionShareSimplePrecomputed<E>],
 ) -> E::Fqk {
-    // $s = ∏C_{λ_i}$, where $λ_i$ is the Lagrange coefficient for $i$.
+    // s = ∏ C_{λ_i}, where λ_i is the Lagrange coefficient for i
     shares
         .iter()
         .fold(E::Fqk::one(), |acc, c_i| acc * c_i.decryption_share)

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -37,6 +37,7 @@ pub fn prepare_combine_simple<E: PairingEngine>(
 ) -> Vec<E::Fr> {
     // See https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
     // In this formula x_i = 0, hence numerator is x_m
+    // See https://en.wikipedia.org/wiki/Lagrange_polynomial#Optimal_algorithm
     lagrange_basis_at::<E>(domain, &E::Fr::zero())
 }
 

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -140,4 +140,22 @@ impl<E: PairingEngine> PrivateDecryptionContextSimple<E> {
             decryption_share: c_i,
         }
     }
+
+    pub fn create_share_precomputed(
+        &self,
+        ciphertext: &Ciphertext<E>,
+        lagrange_coeff: &E::Fr,
+    ) -> DecryptionShareSimplePrecomputed<E> {
+        // TODO: Update formulas
+        let u = ciphertext.commitment;
+        let u_to_lagrange_coeff = u.mul(lagrange_coeff.into_repr());
+        let z_i = self.private_key_share.clone();
+        let z_i = z_i.private_key_shares[0];
+        // C_i = e(U, Z_i)
+        let c_i = E::pairing(u_to_lagrange_coeff, z_i);
+        DecryptionShareSimplePrecomputed {
+            decrypter_index: self.index,
+            decryption_share: c_i,
+        }
+    }
 }

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -51,11 +51,11 @@ impl<E: PairingEngine> PrivateDecryptionContextFast<E> {
             decryption_share,
         }
     }
+
     pub fn batch_verify_decryption_shares<R: RngCore>(
         &self,
         ciphertexts: &[Ciphertext<E>],
         shares: &[Vec<DecryptionShareFast<E>>],
-        //ciphertexts_and_shares: &[(Ciphertext<E>, Vec<DecryptionShare<E>>)],
         rng: &mut R,
     ) -> bool {
         let num_ciphertexts = ciphertexts.len();
@@ -149,7 +149,7 @@ impl<E: PairingEngine> PrivateDecryptionContextSimple<E> {
         let u = ciphertext.commitment;
         let u_to_lagrange_coeff = u.mul(lagrange_coeff.into_repr());
         let z_i = self.private_key_share.clone();
-        let z_i = z_i.private_key_shares[0];
+        let z_i = z_i.private_key_share;
         // $C_{λ_i}=e(U_{λ_i},Z_i)$, where $U_{λ_i} = [λ_{i}(0)]U$$
         let c_i = E::pairing(u_to_lagrange_coeff, z_i);
         DecryptionShareSimplePrecomputed {

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -146,12 +146,11 @@ impl<E: PairingEngine> PrivateDecryptionContextSimple<E> {
         ciphertext: &Ciphertext<E>,
         lagrange_coeff: &E::Fr,
     ) -> DecryptionShareSimplePrecomputed<E> {
-        // TODO: Update formulas
         let u = ciphertext.commitment;
         let u_to_lagrange_coeff = u.mul(lagrange_coeff.into_repr());
         let z_i = self.private_key_share.clone();
         let z_i = z_i.private_key_shares[0];
-        // C_i = e(U, Z_i)
+        // $C_{λ_i}=e(U_{λ_i},Z_i)$, where $U_{λ_i} = [λ_{i}(0)]U$$
         let c_i = E::pairing(u_to_lagrange_coeff, z_i);
         DecryptionShareSimplePrecomputed {
             decrypter_index: self.index,

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -147,10 +147,11 @@ impl<E: PairingEngine> PrivateDecryptionContextSimple<E> {
         lagrange_coeff: &E::Fr,
     ) -> DecryptionShareSimplePrecomputed<E> {
         let u = ciphertext.commitment;
+        // U_{λ_i} = [λ_{i}(0)] U
         let u_to_lagrange_coeff = u.mul(lagrange_coeff.into_repr());
         let z_i = self.private_key_share.clone();
         let z_i = z_i.private_key_share;
-        // $C_{λ_i}=e(U_{λ_i},Z_i)$, where $U_{λ_i} = [λ_{i}(0)]U$$
+        // C_{λ_i} = e(U_{λ_i}, Z_i)
         let c_i = E::pairing(u_to_lagrange_coeff, z_i);
         DecryptionShareSimplePrecomputed {
             decrypter_index: self.index,

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -131,8 +131,7 @@ impl<E: PairingEngine> PrivateDecryptionContextSimple<E> {
         ciphertext: &Ciphertext<E>,
     ) -> DecryptionShareSimple<E> {
         let u = ciphertext.commitment;
-        let z_i = self.private_key_share.clone();
-        let z_i = z_i.private_key_share;
+        let z_i = self.private_key_share.private_key_share;
         // C_i = e(U, Z_i)
         let c_i = E::pairing(u, z_i);
         DecryptionShareSimple {
@@ -149,8 +148,7 @@ impl<E: PairingEngine> PrivateDecryptionContextSimple<E> {
         let u = ciphertext.commitment;
         // U_{λ_i} = [λ_{i}(0)] U
         let u_to_lagrange_coeff = u.mul(lagrange_coeff.into_repr());
-        let z_i = self.private_key_share.clone();
-        let z_i = z_i.private_key_share;
+        let z_i = self.private_key_share.private_key_share;
         // C_{λ_i} = e(U_{λ_i}, Z_i)
         let c_i = E::pairing(u_to_lagrange_coeff, z_i);
         DecryptionShareSimplePrecomputed {

--- a/tpke/src/decryption.rs
+++ b/tpke/src/decryption.rs
@@ -42,6 +42,12 @@ pub struct DecryptionShareSimple<E: PairingEngine> {
     pub decryption_share: E::Fqk,
 }
 
+#[derive(Debug, Clone)]
+pub struct DecryptionShareSimplePrecomputed<E: PairingEngine> {
+    pub decrypter_index: usize,
+    pub decryption_share: E::Fqk,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::*;

--- a/tpke/src/key_share.rs
+++ b/tpke/src/key_share.rs
@@ -11,9 +11,18 @@ pub struct PublicKeyShare<E: PairingEngine> {
 
 #[derive(Debug, Clone)]
 pub struct BlindedKeyShare<E: PairingEngine> {
-    pub blinding_key: E::G2Affine,      // [b] H
-    pub blinded_key_share: E::G2Affine, // [b] Z_{i, \omega_i}
+    pub blinding_key: E::G2Affine,
+    // [b] H
+    pub blinded_key_share: E::G2Affine,
+    // [b] Z_{i, \omega_i}
     pub blinding_key_prepared: E::G2Prepared,
+}
+
+pub fn generate_random<R: RngCore, E: PairingEngine>(
+    n: usize,
+    rng: &mut R,
+) -> Vec<E::Fr> {
+    (0..n).map(|_| E::Fr::rand(rng)).collect::<Vec<_>>()
 }
 
 impl<E: PairingEngine> BlindedKeyShare<E> {

--- a/tpke/src/key_share.rs
+++ b/tpke/src/key_share.rs
@@ -11,10 +11,8 @@ pub struct PublicKeyShare<E: PairingEngine> {
 
 #[derive(Debug, Clone)]
 pub struct BlindedKeyShare<E: PairingEngine> {
-    pub blinding_key: E::G2Affine,
-    // [b] H
-    pub blinded_key_share: E::G2Affine,
-    // [b] Z_{i, \omega_i}
+    pub blinding_key: E::G2Affine,      // [b] H
+    pub blinded_key_share: E::G2Affine, // [b] Z_{i, \omega_i}
     pub blinding_key_prepared: E::G2Prepared,
 }
 

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -390,38 +390,6 @@ mod tests {
         let msg: &[u8] = "abc".as_bytes();
         let aad: &[u8] = "my-aad".as_bytes();
 
-        let (pubkey, _privkey, contexts) =
-            setup_fast::<E>(threshold, shares_num, &mut rng);
-        let ciphertext = encrypt::<_, E>(msg, aad, &pubkey, rng);
-
-        let mut shares: Vec<DecryptionShareFast<E>> = vec![];
-        for context in contexts.iter() {
-            shares.push(context.create_share(&ciphertext));
-        }
-
-        /*for pub_context in contexts[0].public_decryption_contexts.iter() {
-            assert!(pub_context
-                .blinded_key_shares
-                .verify_blinding(&pub_context.public_key_shares, rng));
-        }*/
-        let prepared_blinded_key_shares = prepare_combine_fast(
-            &contexts[0].public_decryption_contexts,
-            &shares,
-        );
-        let shared_secret =
-            share_combine_fast(&shares, &prepared_blinded_key_shares);
-
-        test_ciphertext_validation_fails(msg, aad, &ciphertext, &shared_secret);
-    }
-
-    #[test]
-    fn fast_threshold_encryption() {
-        let mut rng = &mut test_rng();
-        let threshold = 16 * 2 / 3;
-        let shares_num = 16;
-        let msg: &[u8] = "abc".as_bytes();
-        let aad: &[u8] = "my-aad".as_bytes();
-
         let (pubkey, _, contexts) =
             setup_fast::<E>(threshold, shares_num, &mut rng);
         let ciphertext = encrypt::<_, E>(msg, aad, &pubkey, rng);

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -271,12 +271,23 @@ pub fn generate_random<R: RngCore, E: PairingEngine>(
     (0..n).map(|_| E::Fr::rand(rng)).collect::<Vec<_>>()
 }
 
+fn make_decryption_share<E: PairingEngine>(
+    private_share: &PrivateKeyShare<E>,
+    ciphertext: &Ciphertext<E>,
+) -> E::Fqk {
+    let z_i = private_share;
+    let u = ciphertext.commitment;
+    let z_i = z_i.private_key_shares[0];
+    E::pairing(u, z_i)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::*;
     use ark_bls12_381::Fr;
     use ark_ec::ProjectiveCurve;
     use ark_std::test_rng;
+    use itertools::Itertools;
     use rand::prelude::StdRng;
 
     type E = ark_bls12_381::Bls12_381;


### PR DESCRIPTION
- Closes to #30 
- Implements a subvariant of a simple threshold decryption variant where an expensive exponentiation operation is moved from the aggregator to the decryption share creator (node). Concretely: 
   - [We're calculating decryption shares](https://github.com/nucypher/ferveo/pull/32/files#diff-69e366464f9323bf110a902e9444189646025e090a9b154070b5f54437ecec7fR149), $C_{λ_i}=e(U_{λ_i},Z_i)$, where $U_{λ_i} = [λ_{i}(0)]U$
   - [We're combining decryption shares](https://github.com/nucypher/ferveo/pull/32/files#diff-70820b5fd4b35ef49feefd0f6fdbbe78f758f7ac666ac7b1b61c589aa279c510R114),  $s = ∏C_{λ_i}$
- Notes for reviewers
  - Notice that Lagrange coefficient computation is not a part of the benchmark. In the original simple tDec, it happens during share aggregation. In this variant, it happens on the "server-side" before decryption share creation.
  - Does not handle the [pessimistic scenario](https://github.com/nucypher/ferveo/issues/30#issuecomment-1377500058)

<details>
<summary>Latest benchmarks comparing simple tDec with precomputed tDec variants:</summary>

![create](https://user-images.githubusercontent.com/39299780/211541539-f5b6940b-d154-4787-8c21-4f3cb91aa22f.svg)

![combine](https://user-images.githubusercontent.com/39299780/211541541-973e678b-82af-49e3-963c-581029da1a5f.svg)

</details>


