### PR TITLE
Expose `ExternalValidator`, `DecryptionShare`, `Ciphertext` python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 *.wasm
 tpke-python/py-benches/inputs/
+.venv

--- a/ferveo-python/examples/server_api.py
+++ b/ferveo-python/examples/server_api.py
@@ -7,6 +7,7 @@ from ferveo_py import (
     Transcript,
     Dkg,
     AggregatedTranscript,
+    Ciphertext,
 )
 
 tau = 1
@@ -48,13 +49,14 @@ assert pvss_aggregated.validate(dkg)
 transcripts_ser = [bytes(transcript) for _, transcript in messages]
 transcripts_deser = [Transcript.from_bytes(t) for t in transcripts_ser]
 
-agg_transcript_ser = bytes(pvss_aggregated)
-agg_transcript_deser = AggregatedTranscript.from_bytes(agg_transcript_ser)
-
 # In the meantime, the client creates a ciphertext and decryption request
 msg = "abc".encode()
 aad = "my-aad".encode()
 ciphertext = encrypt(msg, aad, dkg.final_key)
+
+# The client can serialize/deserialize ciphertext for transport
+ciphertext_ser = bytes(ciphertext)
+ciphertext_deser = Ciphertext.from_bytes(ciphertext_ser)
 
 # Having aggregated the transcripts, the validators can now create decryption shares
 decryption_shares = []

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -151,7 +151,6 @@ impl Transcript {
 #[derive(Clone, derive_more::From, derive_more::AsRef)]
 pub struct DkgPublicKey(ferveo::api::DkgPublicKey);
 
-
 #[derive(FromPyObject)]
 pub struct ExternalValidatorMessage(ExternalValidator, Transcript);
 

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -119,6 +119,16 @@ impl ExternalValidator {
     pub fn new(address: String, public_key: PublicKey) -> Self {
         Self(ferveo::api::ExternalValidator::new(address, public_key.0))
     }
+
+    #[getter]
+    pub fn address(&self) -> String {
+        self.0.address.to_string()
+    }
+
+    #[getter]
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey(self.0.public_key)
+    }
 }
 
 #[pyclass(module = "ferveo")]

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -239,6 +239,18 @@ pub struct UnblindingKey(ferveo::api::UnblindingKey);
 #[derive(Clone, derive_more::AsRef, derive_more::From)]
 pub struct DecryptionShare(ferveo::api::DecryptionShare);
 
+#[pymethods]
+impl DecryptionShare {
+    #[staticmethod]
+    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
+        from_py_bytes(bytes).map(Self)
+    }
+
+    fn __bytes__(&self) -> PyResult<PyObject> {
+        to_py_bytes(&self.0)
+    }
+}
+
 #[pyclass(module = "ferveo")]
 #[derive(derive_more::From, derive_more::AsRef)]
 pub struct AggregatedTranscript(ferveo::api::AggregatedTranscript);

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -151,6 +151,7 @@ impl Transcript {
 #[derive(Clone, derive_more::From, derive_more::AsRef)]
 pub struct DkgPublicKey(ferveo::api::DkgPublicKey);
 
+
 #[derive(FromPyObject)]
 pub struct ExternalValidatorMessage(ExternalValidator, Transcript);
 
@@ -218,6 +219,18 @@ impl Dkg {
 #[pyclass(module = "ferveo")]
 #[derive(derive_more::From, derive_more::AsRef)]
 pub struct Ciphertext(ferveo::api::Ciphertext);
+
+#[pymethods]
+impl Ciphertext {
+    #[staticmethod]
+    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
+        from_py_bytes(bytes).map(Self)
+    }
+
+    fn __bytes__(&self) -> PyResult<PyObject> {
+        to_py_bytes(&self.0)
+    }
+}
 
 #[pyclass(module = "ferveo")]
 #[derive(derive_more::From, derive_more::AsRef)]


### PR DESCRIPTION
based on PR #75 

##### what this does

Exposes the following python bindings:

- `ExternalValidator.public_key`
- `ExternalValidator.address`
- `Ciphertext.__bytes__`
- `Ciphertext.from_bytes`
- `DecryptionShare.__bytes__`
- `DecryptionShare.from_bytes`
