### PR TITLE
Use typed errors in user-facing APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,6 @@ dependencies = [
 name = "ferveo"
 version = "0.1.1"
 dependencies = [
- "anyhow",
  "ark-bls12-381",
  "ark-ec",
  "ark-ff",
@@ -785,7 +784,7 @@ dependencies = [
  "ferveo",
  "ferveo-common",
  "pyo3",
- "pyo3-build-config 0.18.1",
+ "pyo3-build-config 0.17.3",
  "rand 0.8.5",
 ]
 
@@ -1119,6 +1118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,16 +1375,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.8.0",
  "parking_lot 0.12.1",
- "pyo3-build-config 0.17.3",
+ "pyo3-build-config 0.18.2",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -1394,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
+checksum = "98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1404,19 +1412,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d"
 dependencies = [
  "libc",
- "pyo3-build-config 0.17.3",
+ "pyo3-build-config 0.18.2",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1426,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1933,7 +1941,7 @@ dependencies = [
  "ferveo-common",
  "group-threshold-cryptography",
  "pyo3",
- "pyo3-build-config 0.18.1",
+ "pyo3-build-config 0.17.3",
 ]
 
 [[package]]

--- a/ferveo-python/Cargo.toml
+++ b/ferveo-python/Cargo.toml
@@ -11,7 +11,7 @@ name = "ferveo_py"
 [dependencies]
 ferveo = { path = "../ferveo" }
 ferveo-common = { path = "../ferveo-common" }
-pyo3 = { version = "0.17.3", features = ["macros", "extension-module"] }
+pyo3 = { version = "0.18.2", features = ["macros", "extension-module"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref"] }
 rand = "0.8"
 

--- a/ferveo-python/examples/server_api.py
+++ b/ferveo-python/examples/server_api.py
@@ -8,6 +8,7 @@ from ferveo_py import (
     Dkg,
     AggregatedTranscript,
     Ciphertext,
+    DkgPublicKey,
 )
 
 tau = 1
@@ -88,3 +89,15 @@ shared_secret = combine_decryption_shares(decryption_shares)
 
 plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.g1_inv)
 assert bytes(plaintext) == msg
+
+# Other serializable objects
+
+# Keypair
+keypair = Keypair.random()
+keypair_ser = bytes(keypair)
+keypair_deser = Keypair.from_bytes(keypair_ser)
+
+# DKG public key
+dkg_pk = dkg.final_key
+dkg_pk_ser = bytes(dkg_pk)
+dkg_pk_deser = DkgPublicKey.from_bytes(dkg_pk_ser)

--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -11,4 +11,5 @@ from .ferveo_py import (
     UnblindingKey,
     DecryptionShare,
     AggregatedTranscript,
+    DkgPublicKey,
 )

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -25,22 +25,32 @@ class PublicKey:
         ...
 
 
-class Validator:
-    ...
-
-
 class ExternalValidator:
 
     def __init__(self, address: str, public_key: PublicKey):
         ...
 
+    address: str
+
+    public_key: PublicKey
+
 
 class Transcript:
-    ...
+    @staticmethod
+    def from_bytes(data: bytes) -> Transcript:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
 
 
 class DkgPublicKey:
-    ...
+    @staticmethod
+    def from_bytes(data: bytes) -> DkgPublicKey:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
 
 
 class ExternalValidatorMessage:
@@ -69,7 +79,12 @@ class Dkg:
 
 
 class Ciphertext:
-    ...
+    @staticmethod
+    def from_bytes(data: bytes) -> Ciphertext:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
 
 
 class UnblindingKey:
@@ -77,7 +92,12 @@ class UnblindingKey:
 
 
 class DecryptionShare:
-    ...
+    @staticmethod
+    def from_bytes(data: bytes) -> DecryptionShare:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
 
 
 class AggregatedTranscript:
@@ -89,4 +109,14 @@ class AggregatedTranscript:
             aad: bytes,
             unblinding_key: UnblindingKey
     ) -> DecryptionShare:
+        ...
+
+    def validate(self, dkg: Dkg) -> bool:
+        ...
+
+    @staticmethod
+    def from_bytes(data: bytes) -> AggregatedTranscript:
+        ...
+
+    def __bytes__(self) -> bytes:
         ...

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -56,7 +56,7 @@ pub fn decrypt_with_shared_secret(
         &shared_secret.0,
         &g1_inv.0,
     )
-    .map_err(|err| PyValueError::new_err(format!("{}", err)))
+    .map_err(map_py_error)
 }
 
 #[pyclass(module = "ferveo")]
@@ -94,7 +94,7 @@ impl Keypair {
 }
 
 #[pyclass(module = "ferveo")]
-#[derive(Clone, derive_more::From, derive_more::AsRef)]
+#[derive(Clone, PartialEq, Eq, derive_more::From, derive_more::AsRef)]
 pub struct PublicKey(ferveo::api::PublicKey<E>);
 
 #[pymethods]
@@ -188,7 +188,7 @@ impl Dkg {
             &validators,
             &me.0,
         )
-        .map_err(|err| PyValueError::new_err(format!("{}", err)))?;
+        .map_err(map_py_error)?;
         Ok(Self(dkg))
     }
 
@@ -199,10 +199,8 @@ impl Dkg {
 
     pub fn generate_transcript(&self) -> PyResult<Transcript> {
         let rng = &mut thread_rng();
-        let transcript = self
-            .0
-            .generate_transcript(rng)
-            .map_err(|err| PyValueError::new_err(format!("{}", err)))?;
+        let transcript =
+            self.0.generate_transcript(rng).map_err(map_py_error)?;
         Ok(Transcript(transcript))
     }
 
@@ -217,7 +215,7 @@ impl Dkg {
         let aggregated_transcript = self
             .0
             .aggregate_transcripts(&transcripts)
-            .map_err(|err| PyValueError::new_err(format!("{}", err)))?;
+            .map_err(map_py_error)?;
         Ok(AggregatedTranscript(aggregated_transcript))
     }
 
@@ -288,7 +286,7 @@ impl AggregatedTranscript {
                 aad,
                 &validator_keypair.0,
             )
-            .map_err(|err| PyValueError::new_err(format!("{}", err)))?;
+            .map_err(map_py_error)?;
         Ok(DecryptionShare(decryption_share))
     }
 

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -29,7 +29,7 @@ pub fn encrypt(
     public_key: &DkgPublicKey,
 ) -> PyResult<Ciphertext> {
     let rng = &mut thread_rng();
-    let ciphertext = ferveo::api::encrypt(message, aad, &public_key.0, rng)
+    let ciphertext = ferveo::api::encrypt(message, aad, &public_key.0 .0, rng)
         .map_err(map_py_error)?;
     Ok(Ciphertext(ciphertext))
 }
@@ -150,6 +150,18 @@ impl Transcript {
 #[pyclass(module = "ferveo")]
 #[derive(Clone, derive_more::From, derive_more::AsRef)]
 pub struct DkgPublicKey(ferveo::api::DkgPublicKey);
+
+#[pymethods]
+impl DkgPublicKey {
+    #[staticmethod]
+    pub fn from_bytes(bytes: &[u8]) -> PyResult<Self> {
+        from_py_bytes(bytes).map(Self)
+    }
+
+    fn __bytes__(&self) -> PyResult<PyObject> {
+        to_py_bytes(self.0)
+    }
+}
 
 #[derive(FromPyObject)]
 pub struct ExternalValidatorMessage(ExternalValidator, Transcript);
@@ -305,5 +317,6 @@ fn ferveo_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<UnblindingKey>()?;
     m.add_class::<DecryptionShare>()?;
     m.add_class::<AggregatedTranscript>()?;
+    m.add_class::<DkgPublicKey>()?;
     Ok(())
 }

--- a/ferveo-python/src/lib.rs
+++ b/ferveo-python/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use std::fmt;
+use std::fmt::{self};
 
 use ferveo::api::E;
 use ferveo_common::serialization::{FromBytes, ToBytes};

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 authors = ["Heliax AG <hello@heliax.dev>"]
 
 [dependencies]
-group-threshold-cryptography = { path = "../tpke" }
+group-threshold-cryptography = { path = "../tpke"}
 ferveo-common = { path = "../ferveo-common" }
 subproductdomain = { path = "../subproductdomain" }
 ark-std = "0.4"
@@ -28,7 +28,6 @@ measure_time = "0.8"
 rand_core = "0.6.4"
 serde_with = "2.0.1"
 thiserror = "1.0"
-anyhow = "1.0"
 
 [dev-dependencies]
 criterion = "0.3" # supports pprof, # TODO: Figure out if/how we can update to 0.4

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -40,7 +40,7 @@ impl Dkg {
     }
 
     pub fn final_key(&self) -> DkgPublicKey {
-        self.0.final_key()
+        DkgPublicKey(self.0.final_key())
     }
 
     pub fn generate_transcript<R: RngCore>(
@@ -154,7 +154,7 @@ mod test_ferveo_api {
         let msg: &[u8] = "abc".as_bytes();
         let aad: &[u8] = "my-aad".as_bytes();
         let rng = &mut thread_rng();
-        let ciphertext = encrypt(msg, aad, &public_key, rng).unwrap();
+        let ciphertext = encrypt(msg, aad, &public_key.0, rng).unwrap();
 
         // Having aggregated the transcripts, the validators can now create decryption shares
         let decryption_shares: Vec<_> = izip!(&validators, &validator_keypairs)

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -3,7 +3,6 @@ pub mod dkg;
 pub mod primitives;
 mod vss;
 
-// TODO: Replace with concrete error type
 pub use dkg::*;
 use group_threshold_cryptography as tpke;
 pub use primitives::*;
@@ -15,27 +14,59 @@ pub enum Error {
     #[error("Threshold encryption error")]
     ThresholdEncryptionError(#[from] tpke::Error),
 
-    // /// Not all validator session keys have been announced
-    // #[error("Not enough validators (expected {0}, got {1})")]
-    // InvalidValidatorCount(usize, usize),
-    //
-    // /// Aggregation does not match received PVSS instances
-    // #[error("Aggregation does not match received PVSS instances")]
-    // InvalidAggregation,
-    //
-    // /// Number of shares parameter must be a power of two
-    // #[error("Number of shares parameter must be a power of two. Got {0}")]
-    // InvalidShareNumberParameter(usize),
-    //
-    // /// DKG is not in a valid state to deal PVSS shares
-    // #[error("Invalid DKG state")]
-    // InvalidDkgState(),
-    //
-    // /// Not enough PVSS transcripts received to aggregate
-    // #[error("Not enough PVSS transcripts received to aggregate (expected {0}, got {1})")]
-    // NotEnoughPVSSTranscripts(usize, usize),
-    #[error("Something went wrong")]
-    Other(#[from] anyhow::Error),
+    /// Number of shares parameter must be a power of two
+    #[error("Number of shares parameter must be a power of two. Got {0}")]
+    InvalidShareNumberParameter(u32),
+
+    /// DKG is not in a valid state to deal PVSS shares
+    #[error("Invalid DKG state to deal PVSS shares")]
+    InvalidDkgStateToDeal,
+
+    /// DKG is not in a valid state to aggregate PVSS transcripts
+    #[error("Invalid DKG state to aggregate PVSS transcripts")]
+    InvalidDkgStateToAggregate,
+
+    /// DKG is not in a valid state to verify PVSS transcripts
+    #[error("Invalid DKG state to verify PVSS transcripts")]
+    InvalidDkgStateToVerify,
+
+    /// DKG is not in a valid state to ingest PVSS transcripts
+    #[error("Invalid DKG state to ingest PVSS transcripts")]
+    InvalidDkgStateToIngest,
+
+    /// DKG validator set must contain the validator with the given address
+    #[error("Expected validator to be a part of the DKG validator set: {0}")]
+    ValidatorNotInSet(String),
+
+    /// DKG received an unknown dealer. Dealer must be the part of the DKG validator set.
+    #[error("DKG received an unknown dealer: {0}")]
+    UnknownDealer(String),
+
+    /// DKG received a PVSS transcript from a dealer that has already been dealt.
+    #[error("DKG received a PVSS transcript from a dealer that has already been dealt: {0}")]
+    DuplicateDealer(String),
+
+    /// DKG received an invalid transcript for which optimistic verification failed
+    #[error("DKG received an invalid transcript")]
+    InvalidPvssTranscript,
+
+    /// Aggregation failed because the DKG did not receive enough PVSS transcripts
+    #[error(
+        "Insufficient transcripts for aggregation (expected {0}, got {1})"
+    )]
+    InsufficientTranscriptsForAggregate(u32, u32),
+
+    /// Failed to derive a valid final key for the DKG
+    #[error("Failed to derive a valid final key for the DKG")]
+    InvalidFinalKey,
+
+    /// Not enough validators to perform the DKG for a given number of shares
+    #[error("Not enough validators (expected {0}, got {1})")]
+    InsufficientValidators(u32, u32),
+
+    /// Transcript aggregate doesn't match the received PVSS instances
+    #[error("Transcript aggregate doesn't match the received PVSS instances")]
+    InvalidTranscriptAggregate,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tpke-python/Cargo.toml
+++ b/tpke-python/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.17.3"
+pyo3 = "0.18.2"
 group-threshold-cryptography = { path = "../tpke" }
 ferveo-common = { path = "../ferveo-common" }
 

--- a/tpke/src/api.rs
+++ b/tpke/src/api.rs
@@ -1,11 +1,11 @@
 //! Contains the public API of the library.
 
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ferveo_common::serialization;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 pub type E = ark_bls12_381::Bls12_381;
-pub type DkgPublicKey = ark_bls12_381::G1Affine;
 pub type G1Prepared = <E as ark_ec::pairing::Pairing>::G1Prepared;
 pub type PrivateKey = ark_bls12_381::G2Affine;
 pub type UnblindingKey = ark_bls12_381::Fr;
@@ -28,3 +28,24 @@ pub use crate::{
 pub struct DomainPoint(
     #[serde_as(as = "serialization::SerdeAs")] pub ark_bls12_381::Fr,
 );
+
+#[serde_as]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DkgPublicKey(
+    #[serde_as(as = "serialization::SerdeAs")] pub ark_bls12_381::G1Affine,
+);
+
+impl DkgPublicKey {
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let mut writer = Vec::new();
+        self.0.serialize_uncompressed(&mut writer)?;
+        Ok(writer)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<DkgPublicKey> {
+        let mut reader = bytes;
+        let pk =
+            ark_bls12_381::G1Affine::deserialize_uncompressed(&mut reader)?;
+        Ok(Self(pk))
+    }
+}


### PR DESCRIPTION
- Closes #90
- Closes #89 
- Consider adding custom Python Exceptions per enum `Error` variant
- Python traceback example:
```
Traceback (most recent call last):
  File "<...>/ferveo/ferveo-python/examples/server_api.py", line 108, in <module>
    decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.g1_inv)
ValueError: Ciphertext verification failed
```