### PR TITLE
Support simple tDec variant in Python bindings

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -156,10 +156,23 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - run: pip install -e .
+      - name: Install Ferveo Python package
+        run: pip install -e .
         working-directory: ferveo-python
 
-      - run: python examples/server_api.py
+      - name: Run Python Ferveo examples (server_api_precomputed)
+        run: python examples/server_api_precomputed.py
+        working-directory: ferveo-python
+
+      - name: Run Python Ferveo examples (server_api_simple)
+        run: python examples/server_api_simple.py
+        working-directory: ferveo-python
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest
         working-directory: ferveo-python
 
   codecov:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "ferveo-python"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "derive_more",
  "ferveo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-poly",
+ "ark-serialize",
  "ark-std",
  "bincode",
  "criterion 0.3.6",
@@ -1953,6 +1954,7 @@ version = "0.1.0-alpha.1"
 dependencies = [
  "ark-serialize",
  "console_error_panic_hook",
+ "ferveo",
  "ferveo-common",
  "getrandom 0.2.8",
  "group-threshold-cryptography",

--- a/ferveo-python/Cargo.toml
+++ b/ferveo-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferveo-python"
 authors = ["Piotr Roslaniec <p.roslaniec@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2018"
 
 [lib]

--- a/ferveo-python/examples/server_api_simple.py
+++ b/ferveo-python/examples/server_api_simple.py
@@ -1,0 +1,102 @@
+from ferveo_py import (
+    encrypt,
+    combine_decryption_shares_simple,
+    decrypt_with_shared_secret,
+    Keypair,
+    PublicKey,
+    ExternalValidator,
+    Transcript,
+    Dkg,
+    Ciphertext,
+    UnblindingKey,
+    DecryptionShareSimple,
+    AggregatedTranscript,
+    DkgPublicKey,
+    DkgPublicParameters,
+    SharedSecret,
+)
+
+tau = 1
+security_threshold = 3
+shares_num = 4
+validator_keypairs = [Keypair.random() for _ in range(0, shares_num)]
+validators = [
+    ExternalValidator(f"validator-{i}", keypair.public_key)
+    for i, keypair in enumerate(validator_keypairs)
+]
+
+# Each validator holds their own DKG instance and generates a transcript every
+# validator, including themselves
+messages = []
+for sender in validators:
+    dkg = Dkg(
+        tau=tau,
+        shares_num=shares_num,
+        security_threshold=security_threshold,
+        validators=validators,
+        me=sender,
+    )
+    messages.append((sender, dkg.generate_transcript()))
+
+# Now that every validator holds a dkg instance and a transcript for every other validator,
+# every validator can aggregate the transcripts
+me = validators[0]
+dkg = Dkg(
+    tau=tau,
+    shares_num=shares_num,
+    security_threshold=security_threshold,
+    validators=validators,
+    me=me,
+)
+# Let's say that we've only received `security_threshold` transcripts
+messages = messages[:security_threshold]
+pvss_aggregated = dkg.aggregate_transcripts(messages)
+assert pvss_aggregated.validate(dkg)
+
+# Server can persist transcripts and the aggregated transcript
+transcripts_ser = [bytes(transcript) for _, transcript in messages]
+_transcripts_deser = [Transcript.from_bytes(t) for t in transcripts_ser]
+agg_transcript_ser = bytes(pvss_aggregated)
+
+# In the meantime, the client creates a ciphertext and decryption request
+msg = "abc".encode()
+aad = "my-aad".encode()
+ciphertext = encrypt(msg, aad, dkg.final_key)
+
+# The client can serialize/deserialize ciphertext for transport
+ciphertext_ser = bytes(ciphertext)
+
+# Having aggregated the transcripts, the validators can now create decryption shares
+decryption_shares = []
+for validator, validator_keypair in zip(validators, validator_keypairs):
+    dkg = Dkg(
+        tau=tau,
+        shares_num=shares_num,
+        security_threshold=security_threshold,
+        validators=validators,
+        me=validator,
+    )
+    # Assume the aggregated transcript is obtained through deserialization from a side-channel
+    agg_transcript_deser = AggregatedTranscript.from_bytes(agg_transcript_ser)
+    agg_transcript_deser.validate(dkg)
+
+    # The ciphertext is obtained from the client
+    ciphertext_deser = Ciphertext.from_bytes(ciphertext_ser)
+
+    # Create a decryption share for the ciphertext
+    decryption_share = agg_transcript_deser.create_decryption_share_simple(
+        dkg, ciphertext, aad, validator_keypair
+    )
+    decryption_shares.append(decryption_share)
+
+# Now, the decryption share can be used to decrypt the ciphertext
+# This part is in the client API
+
+# The client should have access to the public parameters of the DKG
+dkg_public_params_ser = bytes(dkg.public_params)
+dkg_public_params_deser = DkgPublicParameters.from_bytes(dkg_public_params_ser)
+
+shared_secret = combine_decryption_shares_simple(decryption_shares, dkg_public_params_deser)
+
+plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg_public_params_deser)
+assert bytes(plaintext) == msg

--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -1,6 +1,7 @@
 from .ferveo_py import (
     encrypt,
-    combine_decryption_shares,
+    combine_decryption_shares_simple,
+    combine_decryption_shares_precomputed,
     decrypt_with_shared_secret,
     Keypair,
     PublicKey,
@@ -9,8 +10,10 @@ from .ferveo_py import (
     Dkg,
     Ciphertext,
     UnblindingKey,
-    DecryptionShare,
+    DecryptionShareSimple,
+    DecryptionSharePrecomputed,
     AggregatedTranscript,
     DkgPublicKey,
-    DkgPublicParameters
+    DkgPublicParameters,
+    SharedSecret,
 )

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -57,10 +57,6 @@ class DkgPublicKey:
         ...
 
 
-class ExternalValidatorMessage:
-    ...
-
-
 class Dkg:
 
     def __init__(
@@ -94,12 +90,27 @@ class Ciphertext:
 
 
 class UnblindingKey:
-    ...
 
-
-class DecryptionShare:
     @staticmethod
-    def from_bytes(data: bytes) -> DecryptionShare:
+    def from_bytes(data: bytes) -> Keypair:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+
+class DecryptionShareSimple:
+    @staticmethod
+    def from_bytes(data: bytes) -> DecryptionShareSimple:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+
+class DecryptionSharePrecomputed:
+    @staticmethod
+    def from_bytes(data: bytes) -> DecryptionSharePrecomputed:
         ...
 
     def __bytes__(self) -> bytes:
@@ -117,13 +128,22 @@ class DkgPublicParameters:
 
 class AggregatedTranscript:
 
-    def create_decryption_share(
+    def create_decryption_share_simple(
             self,
             dkg: Dkg,
             ciphertext: Ciphertext,
             aad: bytes,
-            unblinding_key: UnblindingKey
-    ) -> DecryptionShare:
+            validator_keypair: Keypair
+    ) -> DecryptionShareSimple:
+        ...
+
+    def create_decryption_share_precomputed(
+            self,
+            dkg: Dkg,
+            ciphertext: Ciphertext,
+            aad: bytes,
+            validator_keypair: Keypair
+    ) -> DecryptionSharePrecomputed:
         ...
 
     def validate(self, dkg: Dkg) -> bool:
@@ -135,3 +155,49 @@ class AggregatedTranscript:
 
     def __bytes__(self) -> bytes:
         ...
+
+
+class LagrangeCoefficient:
+
+    @staticmethod
+    def from_bytes(data: bytes) -> LagrangeCoefficient:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+
+class SharedSecret:
+
+    @staticmethod
+    def from_bytes(data: bytes) -> SharedSecret:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+
+def encrypt(message: bytes, add: bytes, dkg_public_key: DkgPublicKey) -> Ciphertext:
+    ...
+
+
+def combine_decryption_shares_simple(
+        decryption_shares: Sequence[DecryptionShareSimple],
+        lagrange_coefficients: LagrangeCoefficient,
+) -> bytes:
+    ...
+
+
+def combine_decryption_shares_precomputed(
+        decryption_shares: Sequence[DecryptionSharePrecomputed],
+) -> SharedSecret:
+    ...
+
+
+def decrypt_with_shared_secret(
+        ciphertext: Ciphertext,
+        aad: bytes,
+        shared_secret: SharedSecret,
+        dkg_params: DkgPublicParameters,
+) -> bytes:
+    ...

--- a/ferveo-python/setup.py
+++ b/ferveo-python/setup.py
@@ -10,7 +10,7 @@ setup(
     description="Ferveo DKG scheme",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="0.1.6",
+    version="0.1.7",
     author="Piotr Roslaniec",
     author_email="p.roslaniec@gmail.com",
     url="https://github.com/nucypher/ferveo/tree/master/ferveo-python",

--- a/ferveo-python/test/test_ferveo.py
+++ b/ferveo-python/test/test_ferveo.py
@@ -1,0 +1,111 @@
+import pytest
+
+from ferveo_py import (
+    encrypt,
+    combine_decryption_shares_simple,
+    combine_decryption_shares_precomputed,
+    decrypt_with_shared_secret,
+    Keypair,
+    PublicKey,
+    ExternalValidator,
+    Transcript,
+    Dkg,
+    Ciphertext,
+    UnblindingKey,
+    DecryptionShareSimple,
+    DecryptionSharePrecomputed,
+    AggregatedTranscript,
+    DkgPublicKey,
+    DkgPublicParameters,
+    SharedSecret,
+)
+
+
+def decryption_share_for_variant(variant, agg_transcript):
+    if variant == "simple":
+        return agg_transcript.create_decryption_share_simple
+    elif variant == "precomputed":
+        return agg_transcript.create_decryption_share_precomputed
+    else:
+        raise ValueError("Unknown variant")
+
+
+def combine_shares_for_variant(variant):
+    if variant == "simple":
+        return combine_decryption_shares_simple
+    elif variant == "precomputed":
+        return combine_decryption_shares_precomputed
+    else:
+        raise ValueError("Unknown variant")
+
+
+def scenario_for_variant(variant, shares_num=4, security_threshold=3):
+    if variant not in ["simple", "precomputed"]:
+        raise ValueError("Unknown variant: " + variant)
+
+    tau = 1
+    validator_keypairs = [Keypair.random() for _ in range(0, shares_num)]
+    validators = [
+        ExternalValidator(f"validator-{i}", keypair.public_key)
+        for i, keypair in enumerate(validator_keypairs)
+    ]
+    messages = []
+    for sender in validators:
+        dkg = Dkg(
+            tau=tau,
+            shares_num=shares_num,
+            security_threshold=security_threshold,
+            validators=validators,
+            me=sender,
+        )
+        messages.append((sender, dkg.generate_transcript()))
+    me = validators[0]
+    dkg = Dkg(
+        tau=tau,
+        shares_num=shares_num,
+        security_threshold=security_threshold,
+        validators=validators,
+        me=me,
+    )
+    pvss_aggregated = dkg.aggregate_transcripts(messages)
+    assert pvss_aggregated.validate(dkg)
+    msg = "abc".encode()
+    aad = "my-aad".encode()
+    ciphertext = encrypt(msg, aad, dkg.final_key)
+    decryption_shares = []
+    for validator, validator_keypair in zip(validators, validator_keypairs):
+        dkg = Dkg(
+            tau=tau,
+            shares_num=shares_num,
+            security_threshold=security_threshold,
+            validators=validators,
+            me=validator,
+        )
+        agg_transcript_deser = AggregatedTranscript.from_bytes(bytes(pvss_aggregated))
+        agg_transcript_deser.validate(dkg)
+
+        decryption_share = decryption_share_for_variant('simple', agg_transcript_deser)(
+            dkg, ciphertext, aad, validator_keypair
+        )
+        decryption_shares.append(decryption_share)
+    shared_secret = combine_shares_for_variant('simple')(decryption_shares, dkg.public_params)
+    plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.public_params)
+    assert bytes(plaintext) == msg
+
+
+def test_tdec_workflow_for_simple_variant():
+    # nr of shares must be a multiple of 2
+    for shares_num in [2, 4, 8]:
+        for security_threshold in range(2, shares_num + 2, 4):
+            scenario_for_variant("simple", shares_num, security_threshold)
+
+
+def test_tdec_workflow_for_precomputed_variant():
+    # nr of shares must be a multiple of 2
+    for shares_num in [2, 4, 8]:
+        for security_threshold in range(2, shares_num + 2, 4):
+            scenario_for_variant("precomputed", shares_num, security_threshold)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", "-k", "test_ferveo"])

--- a/ferveo-python/test/test_serialization.py
+++ b/ferveo-python/test/test_serialization.py
@@ -1,0 +1,60 @@
+from ferveo_py import (
+    Keypair,
+    PublicKey,
+    ExternalValidator,
+    Transcript,
+    Dkg,
+    AggregatedTranscript,
+    DkgPublicKey,
+    DkgPublicParameters,
+    SharedSecret,
+)
+
+tau = 1
+security_threshold = 3
+shares_num = 4
+validator_keypairs = [Keypair.random() for _ in range(shares_num)]
+validators = [
+    ExternalValidator(f"validator-{i}", keypair.public_key)
+    for i, keypair in enumerate(validator_keypairs)
+]
+
+
+def make_dkg_public_params():
+    me = validators[0]
+    dkg = Dkg(
+        tau=tau,
+        shares_num=shares_num,
+        security_threshold=security_threshold,
+        validators=validators,
+        me=me,
+    )
+    return dkg.public_params
+
+
+def make_shared_secret():
+    # TODO: implement this
+    pass
+
+
+def test_dkg_public_parameters_serialization():
+    dkg_public_params = make_dkg_public_params()
+    serialized = bytes(dkg_public_params)
+    deserialized = DkgPublicParameters.from_bytes(serialized)
+    # TODO: Implement comparison
+    # assert dkg_public_params == deserialized
+
+
+# def test_shared_secret_serialization():
+#     shared_secret = create_shared_secret_instance()
+#     serialized = bytes(shared_secret)
+#     deserialized = SharedSecret.from_bytes(serialized)
+#     TODO: Implement comparison
+#     assert shared_secret == deserialized
+
+def test_keypair_serialization():
+    keypair = Keypair.random()
+    serialized = bytes(keypair)
+    deserialized = Keypair.from_bytes(serialized)
+    # TODO: Implement comparison
+    # assert keypair == deserialized

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -19,6 +19,7 @@ ark-bls12-381 = "0.4"
 ark-ec = "0.4"
 ark-ff = "0.4"
 ark-poly = "0.4"
+ark-serialize = "0.4"
 rand = "0.8"
 rand_old = { package = "rand", version = "0.7" } # used by benchmarks/pairing.rs
 serde = { version = "1.0", features = ["derive"] }

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -1,4 +1,5 @@
 use ark_poly::EvaluationDomain;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ferveo_common::serialization;
 pub use ferveo_common::{ExternalValidator, Keypair, PublicKey};
 use group_threshold_cryptography as tpke;
@@ -6,12 +7,54 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 pub use tpke::api::{
-    decrypt_with_shared_secret, encrypt, share_combine_simple_precomputed,
-    Ciphertext, DecryptionShareSimplePrecomputed as DecryptionShare,
-    DkgPublicKey, G1Prepared, SharedSecret, UnblindingKey, E,
+    decrypt_with_shared_secret, encrypt, prepare_combine_simple,
+    share_combine_precomputed, share_combine_simple, Ciphertext,
+    DecryptionSharePrecomputed, DecryptionShareSimple, DomainPoint, Fr,
+    G1Affine, G1Prepared, SharedSecret, E,
 };
 
 pub use crate::{PubliclyVerifiableSS as Transcript, Result};
+
+#[serde_as]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DkgPublicKey(
+    #[serde_as(as = "serialization::SerdeAs")] pub G1Affine,
+);
+
+impl DkgPublicKey {
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let mut writer = Vec::new();
+        self.0.serialize_uncompressed(&mut writer)?;
+        Ok(writer)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<DkgPublicKey> {
+        let mut reader = bytes;
+        let pk = G1Affine::deserialize_uncompressed(&mut reader)?;
+        Ok(Self(pk))
+    }
+}
+
+pub type LagrangeCoefficient = FieldPoint;
+pub type UnblindingKey = FieldPoint;
+
+#[serde_as]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FieldPoint(#[serde_as(as = "serialization::SerdeAs")] pub Fr);
+
+impl FieldPoint {
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let mut writer = Vec::new();
+        self.0.serialize_uncompressed(&mut writer)?;
+        Ok(writer)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<FieldPoint> {
+        let mut reader = bytes;
+        let coeff = Fr::deserialize_uncompressed(&mut reader)?;
+        Ok(Self(coeff))
+    }
+}
 
 #[derive(Clone)]
 pub struct Dkg(crate::PubliclyVerifiableDkg<E>);
@@ -67,6 +110,7 @@ impl Dkg {
     pub fn public_params(&self) -> DkgPublicParameters {
         DkgPublicParameters {
             g1_inv: self.0.pvss_params.g_inv(),
+            domain_points: self.0.domain.elements().collect(),
         }
     }
 }
@@ -81,13 +125,13 @@ impl AggregatedTranscript {
         self.0.verify_full(&dkg.0)
     }
 
-    pub fn create_decryption_share(
+    pub fn create_decryption_share_precomputed(
         &self,
         dkg: &Dkg,
         ciphertext: &Ciphertext,
         aad: &[u8],
         validator_keypair: &Keypair<E>,
-    ) -> Result<DecryptionShare> {
+    ) -> Result<DecryptionSharePrecomputed> {
         let domain_points: Vec<_> = dkg.0.domain.elements().collect();
         self.0.make_decryption_share_simple_precomputed(
             ciphertext,
@@ -98,6 +142,22 @@ impl AggregatedTranscript {
             &dkg.0.pvss_params.g_inv(),
         )
     }
+
+    pub fn create_decryption_share_simple(
+        &self,
+        dkg: &Dkg,
+        ciphertext: &Ciphertext,
+        aad: &[u8],
+        validator_keypair: &Keypair<E>,
+    ) -> Result<DecryptionShareSimple> {
+        self.0.make_decryption_share_simple(
+            ciphertext,
+            aad,
+            &validator_keypair.decryption_key,
+            dkg.0.me,
+            &dkg.0.pvss_params.g_inv(),
+        )
+    }
 }
 
 #[serde_as]
@@ -105,6 +165,8 @@ impl AggregatedTranscript {
 pub struct DkgPublicParameters {
     #[serde_as(as = "serialization::SerdeAs")]
     pub g1_inv: G1Prepared,
+    #[serde_as(as = "serialization::SerdeAs")]
+    pub domain_points: Vec<Fr>,
 }
 
 impl DkgPublicParameters {
@@ -125,12 +187,15 @@ mod test_ferveo_api {
     use crate::{api::*, dkg::test_common::*};
 
     #[test]
-    fn test_server_api_simple_tdec_precomputed() {
+    fn test_server_api_tdec_precomputed() {
         let rng = &mut StdRng::seed_from_u64(0);
 
         let tau = 1;
-        let security_threshold = 3;
         let shares_num = 4;
+        // In precomputed variant, the security threshold is equal to the number of shares
+        // TODO: Refactor DKG contractor to not require security threshold or this case
+        // TODO: Or figure out a different way to simplify the precomputed variant API
+        let security_threshold = shares_num;
 
         let validator_keypairs = gen_n_keypairs(shares_num);
         let validators = validator_keypairs
@@ -165,6 +230,9 @@ mod test_ferveo_api {
         let mut dkg =
             Dkg::new(tau, shares_num, security_threshold, &validators, &me)
                 .unwrap();
+
+        // Lets say that we've only receives `security_threshold` transcripts
+        let messages = messages[..security_threshold as usize].to_vec();
         let pvss_aggregated = dkg.aggregate_transcripts(&messages).unwrap();
 
         // At this point, any given validator should be able to provide a DKG public key
@@ -191,7 +259,7 @@ mod test_ferveo_api {
                 let aggregate = dkg.aggregate_transcripts(&messages).unwrap();
                 assert!(pvss_aggregated.validate(&dkg));
                 aggregate
-                    .create_decryption_share(
+                    .create_decryption_share_precomputed(
                         &dkg,
                         &ciphertext,
                         aad,
@@ -204,8 +272,102 @@ mod test_ferveo_api {
         // Now, the decryption share can be used to decrypt the ciphertext
         // This part is part of the client API
 
-        let shared_secret =
-            share_combine_simple_precomputed(&decryption_shares);
+        let shared_secret = share_combine_precomputed(&decryption_shares);
+
+        let plaintext = decrypt_with_shared_secret(
+            &ciphertext,
+            aad,
+            &shared_secret,
+            &dkg.0.pvss_params.g_inv(),
+        )
+        .unwrap();
+        assert_eq!(plaintext, msg);
+    }
+
+    #[test]
+    fn test_server_api_tdec_simple() {
+        let rng = &mut StdRng::seed_from_u64(0);
+
+        let tau = 1;
+        let shares_num = 4;
+        let security_threshold = 3;
+
+        let validator_keypairs = gen_n_keypairs(shares_num);
+        let validators = validator_keypairs
+            .iter()
+            .enumerate()
+            .map(|(i, keypair)| ExternalValidator {
+                address: format!("validator-{}", i),
+                public_key: keypair.public(),
+            })
+            .collect::<Vec<_>>();
+
+        // Each validator holds their own DKG instance and generates a transcript every
+        // every validator, including themselves
+        let messages: Vec<_> = validators
+            .iter()
+            .map(|sender| {
+                let dkg = Dkg::new(
+                    tau,
+                    shares_num,
+                    security_threshold,
+                    &validators,
+                    sender,
+                )
+                .unwrap();
+                (sender.clone(), dkg.generate_transcript(rng).unwrap())
+            })
+            .collect();
+
+        // Now that every validator holds a dkg instance and a transcript for every other validator,
+        // every validator can aggregate the transcripts
+        let me = validators[0].clone();
+        let mut dkg =
+            Dkg::new(tau, shares_num, security_threshold, &validators, &me)
+                .unwrap();
+
+        // Lets say that we've only receives `security_threshold` transcripts
+        let messages = messages[..security_threshold as usize].to_vec();
+        let pvss_aggregated = dkg.aggregate_transcripts(&messages).unwrap();
+
+        // At this point, any given validator should be able to provide a DKG public key
+        let public_key = dkg.final_key();
+
+        // In the meantime, the client creates a ciphertext and decryption request
+        let msg: &[u8] = "abc".as_bytes();
+        let aad: &[u8] = "my-aad".as_bytes();
+        let rng = &mut thread_rng();
+        let ciphertext = encrypt(msg, aad, &public_key.0, rng).unwrap();
+
+        // Having aggregated the transcripts, the validators can now create decryption shares
+        let decryption_shares: Vec<_> = izip!(&validators, &validator_keypairs)
+            .map(|(validator, validator_keypair)| {
+                // Each validator holds their own instance of DKG and creates their own aggregate
+                let mut dkg = Dkg::new(
+                    tau,
+                    shares_num,
+                    security_threshold,
+                    &validators,
+                    validator,
+                )
+                .unwrap();
+                let aggregate = dkg.aggregate_transcripts(&messages).unwrap();
+                assert!(pvss_aggregated.validate(&dkg));
+                aggregate
+                    .create_decryption_share_precomputed(
+                        &dkg,
+                        &ciphertext,
+                        aad,
+                        validator_keypair,
+                    )
+                    .unwrap()
+            })
+            .collect();
+
+        // Now, the decryption share can be used to decrypt the ciphertext
+        // This part is part of the client API
+
+        let shared_secret = share_combine_precomputed(&decryption_shares);
 
         let plaintext = decrypt_with_shared_secret(
             &ciphertext,

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -67,6 +67,10 @@ pub enum Error {
     /// Transcript aggregate doesn't match the received PVSS instances
     #[error("Transcript aggregate doesn't match the received PVSS instances")]
     InvalidTranscriptAggregate,
+
+    /// Serialization error
+    #[error("Serialization error")]
+    SerializationError(#[from] ark_serialize::SerializationError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -83,7 +87,7 @@ mod test_dkg_full {
     use ferveo_common::Keypair;
     use group_threshold_cryptography as tpke;
     use group_threshold_cryptography::{
-        Ciphertext, DecryptionShareSimple, DecryptionShareSimplePrecomputed,
+        Ciphertext, DecryptionSharePrecomputed, DecryptionShareSimple,
     };
     use itertools::{izip, Itertools};
 
@@ -196,7 +200,7 @@ mod test_dkg_full {
             .take(validator_keypairs.len())
             .collect::<Vec<_>>();
 
-        let decryption_shares: Vec<DecryptionShareSimplePrecomputed<E>> =
+        let decryption_shares: Vec<DecryptionSharePrecomputed<E>> =
             validator_keypairs
                 .iter()
                 .enumerate()
@@ -215,7 +219,7 @@ mod test_dkg_full {
                 .collect();
 
         let shared_secret =
-            tpke::share_combine_simple_precomputed::<E>(&decryption_shares);
+            tpke::share_combine_precomputed::<E>(&decryption_shares);
 
         // Combination works, let's decrypt
         let plaintext = tpke::decrypt_with_shared_secret(

--- a/ferveo/src/vss/pvss.rs
+++ b/ferveo/src/vss/pvss.rs
@@ -15,8 +15,8 @@ use serde_with::serde_as;
 use subproductdomain::fast_multiexp;
 use tpke::{
     prepare_combine_simple, refresh_private_key_share,
-    update_share_for_recovery, Ciphertext, DecryptionShareSimple,
-    DecryptionShareSimplePrecomputed, PrivateKeyShare,
+    update_share_for_recovery, Ciphertext, DecryptionSharePrecomputed,
+    DecryptionShareSimple, PrivateKeyShare,
 };
 
 use crate::{
@@ -261,7 +261,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         validator_index: usize,
         domain_points: &[E::ScalarField],
         g_inv: &E::G1Prepared,
-    ) -> Result<DecryptionShareSimplePrecomputed<E>> {
+    ) -> Result<DecryptionSharePrecomputed<E>> {
         let private_key_share = self.decrypt_private_key_share(
             validator_decryption_key,
             validator_index,
@@ -269,7 +269,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
 
         let lagrange_coeffs = prepare_combine_simple::<E>(domain_points);
 
-        DecryptionShareSimplePrecomputed::new(
+        DecryptionSharePrecomputed::new(
             validator_index,
             validator_decryption_key,
             &private_key_share,

--- a/tpke-python/src/lib.rs
+++ b/tpke-python/src/lib.rs
@@ -6,7 +6,7 @@ use ferveo_common::serialization::ToBytes;
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyBytes};
 
 #[pyclass(module = "tpke")]
-pub struct DecryptionShare(tpke::api::DecryptionShareSimplePrecomputed);
+pub struct DecryptionShare(tpke::api::DecryptionSharePrecomputed);
 
 impl DecryptionShare {
     pub fn to_bytes(&self) -> PyResult<PyObject> {

--- a/tpke-wasm/Cargo.toml
+++ b/tpke-wasm/Cargo.toml
@@ -19,6 +19,7 @@ test-common = ["group-threshold-cryptography/test-common"]
 [dependencies]
 group-threshold-cryptography = { path = "../tpke", features = ["test-common", "api"]  }
 ferveo-common = { path = "../ferveo-common" }
+ferveo = { path = "../ferveo" }
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wee_alloc = { version = "0.4.5" }

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -304,9 +304,7 @@ pub fn bench_share_combine(c: &mut Criterion) {
                 .collect();
 
             move || {
-                black_box(share_combine_simple_precomputed::<E>(
-                    &decryption_shares,
-                ));
+                black_box(share_combine_precomputed::<E>(&decryption_shares));
             }
         };
 

--- a/tpke/src/api.rs
+++ b/tpke/src/api.rs
@@ -1,51 +1,33 @@
 //! Contains the public API of the library.
 
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ferveo_common::serialization;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 pub type E = ark_bls12_381::Bls12_381;
 pub type G1Prepared = <E as ark_ec::pairing::Pairing>::G1Prepared;
+pub type G1Affine = <E as ark_ec::pairing::Pairing>::G1Affine;
+pub type Fr = ark_bls12_381::Fr;
 pub type PrivateKey = ark_bls12_381::G2Affine;
-pub type UnblindingKey = ark_bls12_381::Fr;
-pub type SharedSecret = <E as ark_ec::pairing::Pairing>::TargetField;
 pub type Result<T> = crate::Result<T>;
 pub type PrivateDecryptionContextSimple =
     crate::PrivateDecryptionContextSimple<E>;
-pub type DecryptionShareSimplePrecomputed =
-    crate::DecryptionShareSimplePrecomputed<E>;
+pub type DecryptionSharePrecomputed = crate::DecryptionSharePrecomputed<E>;
 pub type DecryptionShareSimple = crate::DecryptionShareSimple<E>;
 pub type Ciphertext = crate::Ciphertext<E>;
+pub type TargetField = <E as ark_ec::pairing::Pairing>::TargetField;
 
 pub use crate::{
     decrypt_symmetric, decrypt_with_shared_secret, encrypt,
-    share_combine_simple_precomputed,
+    prepare_combine_simple, share_combine_precomputed, share_combine_simple,
 };
 
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct DomainPoint(
-    #[serde_as(as = "serialization::SerdeAs")] pub ark_bls12_381::Fr,
-);
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DomainPoint(#[serde_as(as = "serialization::SerdeAs")] pub Fr);
 
 #[serde_as]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct DkgPublicKey(
-    #[serde_as(as = "serialization::SerdeAs")] pub ark_bls12_381::G1Affine,
+pub struct SharedSecret(
+    #[serde_as(as = "serialization::SerdeAs")] pub TargetField,
 );
-
-impl DkgPublicKey {
-    pub fn to_bytes(&self) -> Result<Vec<u8>> {
-        let mut writer = Vec::new();
-        self.0.serialize_uncompressed(&mut writer)?;
-        Ok(writer)
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<DkgPublicKey> {
-        let mut reader = bytes;
-        let pk =
-            ark_bls12_381::G1Affine::deserialize_uncompressed(&mut reader)?;
-        Ok(Self(pk))
-    }
-}

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -17,14 +17,17 @@ use crate::{htp_bls12381_g2, Error, Result};
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Ciphertext<E: Pairing> {
-    #[serde_as(as = "serialization::SerdeAs")]
-    pub commitment: E::G1Affine,
     // U
     #[serde_as(as = "serialization::SerdeAs")]
-    pub auth_tag: E::G2Affine,
+    pub commitment: E::G1Affine,
+
     // W
+    #[serde_as(as = "serialization::SerdeAs")]
+    pub auth_tag: E::G2Affine,
+
+    // V
     #[serde(with = "serde_bytes")]
-    pub ciphertext: Vec<u8>, // V
+    pub ciphertext: Vec<u8>,
 }
 
 impl<E: Pairing> Ciphertext<E> {

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -9,7 +9,7 @@ use subproductdomain::SubproductDomain;
 
 use crate::{
     verify_decryption_shares_fast, Ciphertext, DecryptionShareFast,
-    DecryptionShareSimple, DecryptionShareSimplePrecomputed, Error,
+    DecryptionSharePrecomputed, DecryptionShareSimple, Error,
     PublicDecryptionContextFast, Result,
 };
 
@@ -127,8 +127,8 @@ pub fn share_combine_simple<E: Pairing>(
     )
 }
 
-pub fn share_combine_simple_precomputed<E: Pairing>(
-    shares: &[DecryptionShareSimplePrecomputed<E>],
+pub fn share_combine_precomputed<E: Pairing>(
+    shares: &[DecryptionSharePrecomputed<E>],
 ) -> E::TargetField {
     // s = ∏ C_{λ_i}, where λ_i is the Lagrange coefficient for i
     shares

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -4,8 +4,8 @@ use ark_ec::{pairing::Pairing, CurveGroup};
 
 use crate::{
     check_ciphertext_validity, prepare_combine_simple, BlindedKeyShare,
-    Ciphertext, DecryptionShareFast, DecryptionShareSimple,
-    DecryptionShareSimplePrecomputed, PrivateKeyShare, PublicKeyShare, Result,
+    Ciphertext, DecryptionShareFast, DecryptionSharePrecomputed,
+    DecryptionShareSimple, PrivateKeyShare, PublicKeyShare, Result,
 };
 
 #[derive(Clone, Debug)]
@@ -99,7 +99,7 @@ impl<E: Pairing> PrivateDecryptionContextSimple<E> {
         &self,
         ciphertext: &Ciphertext<E>,
         aad: &[u8],
-    ) -> Result<DecryptionShareSimplePrecomputed<E>> {
+    ) -> Result<DecryptionSharePrecomputed<E>> {
         let domain = self
             .public_decryption_contexts
             .iter()
@@ -107,7 +107,7 @@ impl<E: Pairing> PrivateDecryptionContextSimple<E> {
             .collect::<Vec<_>>();
         let lagrange_coeffs = prepare_combine_simple::<E>(&domain);
 
-        DecryptionShareSimplePrecomputed::new(
+        DecryptionSharePrecomputed::new(
             self.index,
             &self.validator_private_key,
             &self.private_key_share,

--- a/tpke/src/decryption.rs
+++ b/tpke/src/decryption.rs
@@ -154,14 +154,14 @@ impl<E: Pairing> DecryptionShareSimple<E> {
     serialize = "ValidatorShareChecksum<E>: Serialize",
     deserialize = "ValidatorShareChecksum<E>: DeserializeOwned"
 ))]
-pub struct DecryptionShareSimplePrecomputed<E: Pairing> {
+pub struct DecryptionSharePrecomputed<E: Pairing> {
     pub decrypter_index: usize,
     #[serde_as(as = "serialization::SerdeAs")]
     pub decryption_share: E::TargetField,
     pub validator_checksum: ValidatorShareChecksum<E>,
 }
 
-impl<E: Pairing> DecryptionShareSimplePrecomputed<E> {
+impl<E: Pairing> DecryptionSharePrecomputed<E> {
     pub fn new(
         validator_index: usize,
         validator_decryption_key: &E::ScalarField,


### PR DESCRIPTION
- Exposes precomputed tDec variant through Python bindings
- Adds Python tests and examples
- Some renaming
- Releases `ferveo@0.1.7` on PyPi