### PR TITLE
Hide `DkgPublicParams` from external API

### DIFF
--- a/ferveo-python/examples/server_api_precomputed.py
+++ b/ferveo-python/examples/server_api_precomputed.py
@@ -92,7 +92,7 @@ shared_secret = combine_decryption_shares_precomputed(decryption_shares)
 
 # The client should have access to the public parameters of the DKG
 
-plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.public_params)
+plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret)
 assert bytes(plaintext) == msg
 
 print("Success!")

--- a/ferveo-python/examples/server_api_simple.py
+++ b/ferveo-python/examples/server_api_simple.py
@@ -95,7 +95,7 @@ shared_secret = combine_decryption_shares_simple(decryption_shares)
 
 # The client should have access to the public parameters of the DKG
 
-plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.public_params)
+plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret)
 assert bytes(plaintext) == msg
 
 print("Success!")

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -79,8 +79,6 @@ class Dkg:
 
     public_key: DkgPublicKey
 
-    public_params: DkgPublicParameters
-
     def generate_transcript(self) -> Transcript:
         ...
 
@@ -109,15 +107,6 @@ class DecryptionShareSimple:
 class DecryptionSharePrecomputed:
     @staticmethod
     def from_bytes(data: bytes) -> DecryptionSharePrecomputed:
-        ...
-
-    def __bytes__(self) -> bytes:
-        ...
-
-
-class DkgPublicParameters:
-    @staticmethod
-    def from_bytes(data: bytes) -> DkgPublicParameters:
         ...
 
     def __bytes__(self) -> bytes:
@@ -188,7 +177,6 @@ def decrypt_with_shared_secret(
         ciphertext: Ciphertext,
         aad: bytes,
         shared_secret: SharedSecret,
-        dkg_params: DkgPublicParameters,
 ) -> bytes:
     ...
 

--- a/ferveo-python/test/test_ferveo.py
+++ b/ferveo-python/test/test_ferveo.py
@@ -99,15 +99,15 @@ def scenario_for_variant(variant, shares_num, threshold, shares_to_use):
 
     if variant == "simple" and len(decryption_shares) < threshold:
         with pytest.raises(ThresholdEncryptionError):
-            decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.public_params)
+            decrypt_with_shared_secret(ciphertext, aad, shared_secret)
         return
 
     if variant == "precomputed" and len(decryption_shares) < shares_num:
         with pytest.raises(ThresholdEncryptionError):
-            decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.public_params)
+            decrypt_with_shared_secret(ciphertext, aad, shared_secret)
         return
 
-    plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret, dkg.public_params)
+    plaintext = decrypt_with_shared_secret(ciphertext, aad, shared_secret)
     assert bytes(plaintext) == msg
 
 

--- a/ferveo-python/test/test_serialization.py
+++ b/ferveo-python/test/test_serialization.py
@@ -2,7 +2,6 @@ from ferveo_py import (
     Keypair,
     Validator,
     Dkg,
-    DkgPublicParameters,
     DkgPublicKey
 )
 
@@ -22,18 +21,6 @@ validators = [
 validators.sort(key=lambda v: v.address)
 
 
-def make_dkg_public_params():
-    me = validators[0]
-    dkg = Dkg(
-        tau=tau,
-        shares_num=shares_num,
-        security_threshold=security_threshold,
-        validators=validators,
-        me=me,
-    )
-    return dkg.public_params
-
-
 def make_dkg_public_key():
     me = validators[0]
     dkg = Dkg(
@@ -49,14 +36,6 @@ def make_dkg_public_key():
 def make_shared_secret():
     # TODO: implement this
     pass
-
-
-def test_dkg_public_parameters_serialization():
-    dkg_public_params = make_dkg_public_params()
-    serialized = bytes(dkg_public_params)
-    deserialized = DkgPublicParameters.from_bytes(serialized)
-    # TODO: Implement comparison
-    # assert dkg_public_params == deserialized
 
 
 # def test_shared_secret_serialization():

--- a/ferveo-wasm/examples/node/src/main.test.ts
+++ b/ferveo-wasm/examples/node/src/main.test.ts
@@ -66,7 +66,7 @@ function setupTest() {
     tau,
     sharesNum,
     threshold,
-    validator_keypairs,
+    validatorKeypairs: validator_keypairs,
     validators,
     dkg,
     messages,
@@ -83,9 +83,8 @@ describe("ferveo-wasm", () => {
       tau,
       sharesNum,
       threshold,
-      validator_keypairs,
+      validatorKeypairs,
       validators,
-      dkg,
       messages,
       msg,
       aad,
@@ -94,7 +93,7 @@ describe("ferveo-wasm", () => {
 
     // Having aggregated the transcripts, the validators can now create decryption shares
     const decryptionShares: DecryptionShareSimple[] = [];
-    zip(validators, validator_keypairs).forEach(([validator, keypair]) => {
+    zip(validators, validatorKeypairs).forEach(([validator, keypair]) => {
       expect(validator.publicKey.equals(keypair.publicKey)).toBe(true);
 
       const dkg = new Dkg(tau, sharesNum, threshold, validators, validator);
@@ -124,7 +123,6 @@ describe("ferveo-wasm", () => {
       ciphertext,
       aad,
       sharedSecret,
-      dkg.publicParams()
     );
     expect(Buffer.from(plaintext)).toEqual(msg);
   });
@@ -134,9 +132,8 @@ describe("ferveo-wasm", () => {
       tau,
       sharesNum,
       threshold,
-      validator_keypairs,
+      validatorKeypairs,
       validators,
-      dkg,
       messages,
       msg,
       aad,
@@ -145,7 +142,7 @@ describe("ferveo-wasm", () => {
 
     // Having aggregated the transcripts, the validators can now create decryption shares
     const decryptionShares: DecryptionSharePrecomputed[] = [];
-    zip(validators, validator_keypairs).forEach(([validator, keypair]) => {
+    zip(validators, validatorKeypairs).forEach(([validator, keypair]) => {
       const dkg = new Dkg(tau, sharesNum, threshold, validators, validator);
       const aggregate = dkg.aggregateTranscript(messages);
       const isValid = aggregate.verify(sharesNum, messages);
@@ -171,7 +168,6 @@ describe("ferveo-wasm", () => {
       ciphertext,
       aad,
       sharedSecret,
-      dkg.publicParams()
     );
     expect(Buffer.from(plaintext)).toEqual(msg);
   });

--- a/ferveo-wasm/tests/node.rs
+++ b/ferveo-wasm/tests/node.rs
@@ -13,7 +13,6 @@ type TestSetup = (
     Vec<Keypair>,
     Vec<Validator>,
     ValidatorArray,
-    Dkg,
     ValidatorMessageArray,
     Vec<u8>,
     Vec<u8>,
@@ -86,7 +85,6 @@ fn setup_dkg() -> TestSetup {
         validator_keypairs,
         validators,
         validators_js,
-        dkg,
         messages_js,
         msg,
         aad,
@@ -103,7 +101,6 @@ fn tdec_simple() {
         validator_keypairs,
         validators,
         validators_js,
-        dkg,
         messages_js,
         msg,
         aad,
@@ -144,13 +141,8 @@ fn tdec_simple() {
         combine_decryption_shares_simple(&decryption_shares_js).unwrap();
 
     // The client should have access to the public parameters of the DKG
-    let plaintext = decrypt_with_shared_secret(
-        &ciphertext,
-        &aad,
-        &shared_secret,
-        &dkg.public_params(),
-    )
-    .unwrap();
+    let plaintext =
+        decrypt_with_shared_secret(&ciphertext, &aad, &shared_secret).unwrap();
     assert_eq!(msg, plaintext);
 }
 
@@ -163,7 +155,6 @@ fn tdec_precomputed() {
         validator_keypairs,
         validators,
         validators_js,
-        dkg,
         messages_js,
         msg,
         aad,
@@ -204,12 +195,7 @@ fn tdec_precomputed() {
         combine_decryption_shares_precomputed(&decryption_shares_js).unwrap();
 
     // The client should have access to the public parameters of the DKG
-    let plaintext = decrypt_with_shared_secret(
-        &ciphertext,
-        &aad,
-        &shared_secret,
-        &dkg.public_params(),
-    )
-    .unwrap();
+    let plaintext =
+        decrypt_with_shared_secret(&ciphertext, &aad, &shared_secret).unwrap();
     assert_eq!(msg, plaintext);
 }

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -171,11 +171,6 @@ pub fn ferveo_encrypt(
 }
 
 #[wasm_bindgen]
-pub struct DkgPublicParameters(api::DkgPublicParameters);
-
-generate_common_methods!(DkgPublicParameters);
-
-#[wasm_bindgen]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SharedSecret(api::SharedSecret);
 
@@ -211,16 +206,10 @@ pub fn decrypt_with_shared_secret(
     ciphertext: &Ciphertext,
     aad: &[u8],
     shared_secret: &SharedSecret,
-    dkg_public_params: &DkgPublicParameters,
 ) -> JsResult<Vec<u8>> {
     set_panic_hook();
-    api::decrypt_with_shared_secret(
-        &ciphertext.0,
-        aad,
-        &shared_secret.0 .0,
-        &dkg_public_params.0.g1_inv,
-    )
-    .map_err(map_js_err)
+    api::decrypt_with_shared_secret(&ciphertext.0, aad, &shared_secret.0)
+        .map_err(map_js_err)
 }
 
 #[wasm_bindgen]
@@ -288,11 +277,6 @@ impl Dkg {
             .aggregate_transcripts(&messages)
             .map_err(map_js_err)?;
         Ok(AggregatedTranscript(aggregated_transcript))
-    }
-
-    #[wasm_bindgen(js_name = "publicParams")]
-    pub fn public_params(&self) -> DkgPublicParameters {
-        DkgPublicParameters(self.0.public_params())
     }
 }
 


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:**
-  1

**What this does:**
- Removes `DkgPublicKey` from public API (bindings) and replaces it with a default value internally

**Why it's needed:**
- Simplifies user API

**Notes for reviewers:**
- Previously discussed [on Discord](https://discord.com/channels/411401661714792449/412681039178366996/1118171002824822925)

