### PR TITLE
Fix incompatible `DkgPublicKey` byte serialization

### DIFF
--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -34,10 +34,8 @@ serde_with = "2.2.0"
 subproductdomain = { package = "subproductdomain-pre-release", path = "../subproductdomain", version = "0.1.0-alpha.0" }
 thiserror = "1.0"
 zeroize = { version = "1.6.0", default-features = false, features = ["derive"] }
-
-# Shared by Python and WASM bindings
-derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref", "into"], optional = true }
-generic-array = { version = "0.14.7", optional = true }
+generic-array = "0.14.7"
+derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref", "into"] }
 
 # Python bindings
 pyo3 = { version = "0.18.2", features = ["macros", "multiple-pymethods"], optional = true }
@@ -60,8 +58,8 @@ serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2.86", features = ["serde-serialize"] }
 
 [features]
-bindings-python = ["pyo3", "derive_more", "generic-array"]
-bindings-wasm = ["console_error_panic_hook", "derive_more", "getrandom", "js-sys", "wasm-bindgen", "wasm-bindgen-derive", "generic-array"]
+bindings-python = ["pyo3"]
+bindings-wasm = ["console_error_panic_hook", "getrandom", "js-sys", "wasm-bindgen", "wasm-bindgen-derive"]
 
 [[example]]
 name = "bench_primitives_size"

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -37,10 +37,10 @@ zeroize = { version = "1.6.0", default-features = false, features = ["derive"] }
 
 # Shared by Python and WASM bindings
 derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref", "into"], optional = true }
+generic-array = { version = "0.14.7", optional = true }
 
 # Python bindings
 pyo3 = { version = "0.18.2", features = ["macros", "multiple-pymethods"], optional = true }
-generic-array = { version = "0.14.7", optional = true }
 
 # WASM bindings
 console_error_panic_hook = { version = "0.1.7", optional = true }
@@ -61,7 +61,7 @@ wasm-bindgen = { version = "0.2.86", features = ["serde-serialize"] }
 
 [features]
 bindings-python = ["pyo3", "derive_more", "generic-array"]
-bindings-wasm = ["console_error_panic_hook", "derive_more", "getrandom", "js-sys", "wasm-bindgen", "wasm-bindgen-derive"]
+bindings-wasm = ["console_error_panic_hook", "derive_more", "getrandom", "js-sys", "wasm-bindgen", "wasm-bindgen-derive", "generic-array"]
 
 [[example]]
 name = "bench_primitives_size"

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -5,6 +5,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
 use bincode;
 use ferveo_common::serialization;
+use generic_array::{typenum::U48, GenericArray};
 use group_threshold_cryptography as tpke;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -75,12 +76,16 @@ pub struct DkgPublicKey(
 );
 
 impl DkgPublicKey {
-    pub fn to_bytes(&self) -> Result<Vec<u8>> {
-        to_bytes(&self.0)
+    pub fn to_bytes(&self) -> Result<GenericArray<u8, U48>> {
+        let as_bytes = to_bytes(&self.0)?;
+        Ok(GenericArray::<u8, U48>::from_slice(&as_bytes).to_owned())
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<DkgPublicKey> {
-        from_bytes(bytes).map(DkgPublicKey)
+        let bytes =
+            GenericArray::<u8, U48>::from_exact_iter(bytes.iter().cloned())
+                .ok_or(Error::InvalidByteLength(48, bytes.len()))?;
+        from_bytes(&bytes).map(DkgPublicKey)
     }
 
     pub fn serialized_size() -> usize {

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -236,7 +236,7 @@ impl DkgPublicKey {
         Self(api::DkgPublicKey::random())
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = "serializedSize")]
     pub fn serialized_size() -> usize {
         api::DkgPublicKey::serialized_size()
     }

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -219,9 +219,32 @@ generate_common_methods!(DkgPublicKey);
 
 #[wasm_bindgen]
 impl DkgPublicKey {
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: &[u8]) -> JsResult<DkgPublicKey> {
+        api::DkgPublicKey::from_bytes(bytes)
+            .map_err(map_js_err)
+            .map(Self)
+    }
+
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> JsResult<Box<[u8]>> {
+        let bytes = self.0.to_bytes().map_err(map_js_err)?;
+        let bytes: Box<[u8]> = bytes.as_slice().into();
+        Ok(bytes)
+    }
+
     #[wasm_bindgen]
     pub fn random() -> DkgPublicKey {
         Self(api::DkgPublicKey::random())
+    }
+
+    #[wasm_bindgen]
+    pub fn serialized_size() -> usize {
+        api::DkgPublicKey::serialized_size()
+    }
+
+    pub fn equals(&self, other: &DkgPublicKey) -> bool {
+        self.0 == other.0
     }
 }
 

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -241,6 +241,7 @@ impl DkgPublicKey {
         api::DkgPublicKey::serialized_size()
     }
 
+    #[wasm_bindgen]
     pub fn equals(&self, other: &DkgPublicKey) -> bool {
         self.0 == other.0
     }

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -215,8 +215,6 @@ pub fn decrypt_with_shared_secret(
 #[wasm_bindgen]
 pub struct DkgPublicKey(api::DkgPublicKey);
 
-generate_common_methods!(DkgPublicKey);
-
 #[wasm_bindgen]
 impl DkgPublicKey {
     #[wasm_bindgen(js_name = "fromBytes")]

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -98,6 +98,9 @@ pub enum Error {
 
     #[error(transparent)]
     ArkSerializeError(#[from] ark_serialize::SerializationError),
+
+    #[error("Invalid byte length. Expected {0}, got {1}")]
+    InvalidByteLength(usize, usize),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
-  1

**What this does:**
- Fixes incompatibility of `DkgPublicKey` serialized to bytes between Python and WASM bindings

**Why it's needed:**
- Previously added serialization method only affected Python bindings and caused incompatibility with WASM bindings

**Notes for reviewers:**
- Now downstream effect on `nucypher`