### PR TITLE
Fix incorrect signatures in `.pyi` stubs 

### DIFF
--- a/ferveo-python/examples/server_api_precomputed.py
+++ b/ferveo-python/examples/server_api_precomputed.py
@@ -4,6 +4,7 @@ from ferveo_py import (
     decrypt_with_shared_secret,
     Keypair,
     Validator,
+    ValidatorMessage,
     Dkg,
     AggregatedTranscript,
 )
@@ -38,7 +39,7 @@ for sender in validators:
         validators=validators,
         me=sender,
     )
-    messages.append((sender, dkg.generate_transcript()))
+    messages.append(ValidatorMessage(sender, dkg.generate_transcript()))
 
 # Every validator can aggregate the transcripts
 dkg = Dkg(

--- a/ferveo-python/examples/server_api_simple.py
+++ b/ferveo-python/examples/server_api_simple.py
@@ -4,6 +4,7 @@ from ferveo_py import (
     decrypt_with_shared_secret,
     Keypair,
     Validator,
+    ValidatorMessage,
     Dkg,
     AggregatedTranscript,
 )
@@ -36,7 +37,7 @@ for sender in validators:
         validators=validators,
         me=sender,
     )
-    messages.append((sender, dkg.generate_transcript()))
+    messages.append(ValidatorMessage(sender, dkg.generate_transcript()))
 
 # Now that every validator holds a dkg instance and a transcript for every other validator,
 # every validator can aggregate the transcripts

--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -13,7 +13,6 @@ from .ferveo_py import (
     DecryptionSharePrecomputed,
     AggregatedTranscript,
     DkgPublicKey,
-    DkgPublicParameters,
     SharedSecret,
     ValidatorMessage,
     ThresholdEncryptionError,

--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -15,6 +15,7 @@ from .ferveo_py import (
     DkgPublicKey,
     DkgPublicParameters,
     SharedSecret,
+    ValidatorMessage,
     ThresholdEncryptionError,
     InvalidShareNumberParameter,
     InvalidDkgStateToDeal,

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple
+from typing import Sequence
 
 
 class Keypair:
@@ -65,6 +65,19 @@ class DkgPublicKey:
         ...
 
 
+class ValidatorMessage:
+
+    def __init__(
+            self,
+            validator: Validator,
+            transcript: Transcript,
+    ):
+        ...
+
+    validator: Validator
+    transcript: Transcript
+
+
 class Dkg:
 
     def __init__(
@@ -82,7 +95,7 @@ class Dkg:
     def generate_transcript(self) -> Transcript:
         ...
 
-    def aggregate_transcripts(self, messages: Sequence[Tuple[Validator, Transcript]]) -> AggregatedTranscript:
+    def aggregate_transcripts(self, messages: Sequence[ValidatorMessage]) -> AggregatedTranscript:
         ...
 
 
@@ -115,10 +128,10 @@ class DecryptionSharePrecomputed:
 
 class AggregatedTranscript:
 
-    def __init__(self, messages: Sequence[Tuple[Validator, Transcript]]):
+    def __init__(self, messages: Sequence[ValidatorMessage]):
         ...
 
-    def verify(self, shares_num: int, messages: Sequence[Tuple[Validator, Transcript]]) -> bool:
+    def verify(self, shares_num: int, messages: Sequence[ValidatorMessage]) -> bool:
         ...
 
     def create_decryption_share_simple(

--- a/ferveo-python/test/test_ferveo.py
+++ b/ferveo-python/test/test_ferveo.py
@@ -7,6 +7,7 @@ from ferveo_py import (
     decrypt_with_shared_secret,
     Keypair,
     Validator,
+    ValidatorMessage,
     Dkg,
     AggregatedTranscript,
     DkgPublicKey,
@@ -57,7 +58,7 @@ def scenario_for_variant(variant, shares_num, threshold, shares_to_use):
             validators=validators,
             me=sender,
         )
-        messages.append((sender, dkg.generate_transcript()))
+        messages.append(ValidatorMessage(sender, dkg.generate_transcript()))
 
     dkg = Dkg(
         tau=tau,
@@ -143,7 +144,6 @@ TEST_CASES_WITH_THRESHOLD_RANGE = []
 for (shares_num, variant) in PARAMS:
     for threshold in range(1, shares_num):
         TEST_CASES_WITH_THRESHOLD_RANGE.append((variant, shares_num, threshold))
-
 
 # Avoid running this test case as it takes a long time
 # @pytest.mark.parametrize("variant, shares_num, threshold", TEST_CASES_WITH_THRESHOLD_RANGE)


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
- Updates the definition of `ValidatorMessage` in Python bindings
- Replaces former usage in `.pyi` file, examples, etc.

**Issues fixed/closed:**
- Fixes #129

**Why it's needed:**
- To provide correct type hints and concrete types in Python bindings

**Notes for reviewers:**
 - Based on #128 
 - Downstream changes addressed in https://github.com/nucypher/nucypher-core/pull/65