### PR TITLE
Remove powers-of-2 restriction on cohort size

### DIFF
--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -16,7 +16,6 @@ from .ferveo_py import (
     SharedSecret,
     ValidatorMessage,
     ThresholdEncryptionError,
-    InvalidShareNumberParameter,
     InvalidDkgStateToDeal,
     InvalidDkgStateToAggregate,
     InvalidDkgStateToVerify,

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -201,10 +201,6 @@ class ThresholdEncryptionError(Exception):
     pass
 
 
-class InvalidShareNumberParameter(Exception):
-    pass
-
-
 class InvalidDkgStateToDeal(Exception):
     pass
 

--- a/ferveo/benches/bench_main.rs
+++ b/ferveo/benches/bench_main.rs
@@ -7,4 +7,5 @@ criterion_main! {
     // bench_batch_inverse,
     // benchmarks::pairing::ec,
     benchmarks::validity_checks::validity_checks,
+    benchmarks::eval_domain::eval_domain,
 }

--- a/ferveo/benches/benchmarks/eval_domain.rs
+++ b/ferveo/benches/benchmarks/eval_domain.rs
@@ -1,0 +1,57 @@
+#![allow(clippy::redundant_closure)]
+#![allow(clippy::unit_arg)]
+
+pub use ark_bls12_381::Bls12_381 as EllipticCurve;
+use ark_ff::Field;
+use ark_poly::EvaluationDomain;
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion};
+use digest::crypto_common::rand_core::SeedableRng;
+use ferveo_pre_release::*;
+use rand::prelude::StdRng;
+
+const NUM_SHARES_CASES: [usize; 6] = [2, 4, 8, 16, 32, 64];
+
+pub fn bench_eval_domain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("EVAL DOMAIN");
+    group.sample_size(10);
+
+    let rng = &mut StdRng::seed_from_u64(0);
+    let s = ark_bls12_381::Fr::from_random_bytes(&[0u8; 32]).unwrap();
+
+    for shares_num in NUM_SHARES_CASES {
+        let eval_radix2_eval_domain = {
+            let domain =
+                ark_poly::Radix2EvaluationDomain::new(shares_num).unwrap();
+            let phi = SecretPolynomial::<ark_bls12_381::Bls12_381>::new(
+                &s, shares_num, rng,
+            );
+
+            move || {
+                black_box(phi.0.evaluate_over_domain_by_ref(domain));
+            }
+        };
+
+        let eval_mixed_eval_domain = {
+            let domain =
+                ark_poly::MixedRadixEvaluationDomain::new(shares_num).unwrap();
+            let phi = SecretPolynomial::<ark_bls12_381::Bls12_381>::new(
+                &s, shares_num, rng,
+            );
+
+            move || {
+                black_box(phi.0.evaluate_over_domain_by_ref(domain));
+            }
+        };
+
+        group.bench_function(
+            BenchmarkId::new("eval_radix2_eval_domain", shares_num),
+            |b| b.iter(|| eval_radix2_eval_domain()),
+        );
+        group.bench_function(
+            BenchmarkId::new("eval_mixed_eval_domain", shares_num),
+            |b| b.iter(|| eval_mixed_eval_domain()),
+        );
+    }
+}
+
+criterion_group!(eval_domain, bench_eval_domain);

--- a/ferveo/benches/benchmarks/eval_domain.rs
+++ b/ferveo/benches/benchmarks/eval_domain.rs
@@ -21,7 +21,7 @@ pub fn bench_eval_domain(c: &mut Criterion) {
     for shares_num in NUM_SHARES_CASES {
         let eval_radix2_eval_domain = {
             let domain =
-                ark_poly::MixedRadixEvaluationDomain::new(shares_num).unwrap();
+                ark_poly::GeneralEvaluationDomain::new(shares_num).unwrap();
             let phi = SecretPolynomial::<ark_bls12_381::Bls12_381>::new(
                 &s, shares_num, rng,
             );
@@ -33,7 +33,7 @@ pub fn bench_eval_domain(c: &mut Criterion) {
 
         let eval_mixed_eval_domain = {
             let domain =
-                ark_poly::MixedRadixEvaluationDomain::new(shares_num).unwrap();
+                ark_poly::GeneralEvaluationDomain::new(shares_num).unwrap();
             let phi = SecretPolynomial::<ark_bls12_381::Bls12_381>::new(
                 &s, shares_num, rng,
             );

--- a/ferveo/benches/benchmarks/eval_domain.rs
+++ b/ferveo/benches/benchmarks/eval_domain.rs
@@ -21,7 +21,7 @@ pub fn bench_eval_domain(c: &mut Criterion) {
     for shares_num in NUM_SHARES_CASES {
         let eval_radix2_eval_domain = {
             let domain =
-                ark_poly::Radix2EvaluationDomain::new(shares_num).unwrap();
+                ark_poly::MixedRadixEvaluationDomain::new(shares_num).unwrap();
             let phi = SecretPolynomial::<ark_bls12_381::Bls12_381>::new(
                 &s, shares_num, rng,
             );

--- a/ferveo/benches/benchmarks/mod.rs
+++ b/ferveo/benches/benchmarks/mod.rs
@@ -1,3 +1,4 @@
 //pub mod block_proposer;
 // pub mod pairing;
+pub mod eval_domain;
 pub mod validity_checks;

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use ark_poly::{EvaluationDomain, MixedRadixEvaluationDomain};
+use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
 use bincode;
@@ -204,7 +204,7 @@ impl AggregatedTranscript {
         messages: &[ValidatorMessage],
     ) -> Result<bool> {
         let pvss_params = PubliclyVerifiableParams::<E>::default();
-        let domain = MixedRadixEvaluationDomain::<Fr>::new(shares_num as usize)
+        let domain = GeneralEvaluationDomain::<Fr>::new(shares_num as usize)
             .expect("Unable to construct an evaluation domain");
 
         let is_valid_optimistic = self.0.verify_optimistic();

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -238,7 +238,12 @@ impl AggregatedTranscript {
         aad: &[u8],
         validator_keypair: &Keypair,
     ) -> Result<DecryptionSharePrecomputed> {
-        let domain_points: Vec<_> = dkg.0.domain.elements().collect();
+        let domain_points: Vec<_> = dkg
+            .0
+            .domain
+            .elements()
+            .take(dkg.0.dkg_params.shares_num as usize)
+            .collect();
         self.0.make_decryption_share_simple_precomputed(
             ciphertext,
             aad,
@@ -428,6 +433,8 @@ mod test_ferveo_api {
                         assert!(pvss_aggregated
                             .verify(shares_num, &messages)
                             .unwrap());
+
+                        // And then each validator creates their own decryption share
                         aggregate
                             .create_decryption_share_precomputed(
                                 &dkg,

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
+use ark_poly::{EvaluationDomain, MixedRadixEvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
 use bincode;
@@ -204,7 +204,7 @@ impl AggregatedTranscript {
         messages: &[ValidatorMessage],
     ) -> Result<bool> {
         let pvss_params = PubliclyVerifiableParams::<E>::default();
-        let domain = Radix2EvaluationDomain::<Fr>::new(shares_num as usize)
+        let domain = MixedRadixEvaluationDomain::<Fr>::new(shares_num as usize)
             .expect("Unable to construct an evaluation domain");
 
         let is_valid_optimistic = self.0.verify_optimistic();

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -34,9 +34,6 @@ impl From<FerveoPythonError> for PyErr {
                 Error::ThresholdEncryptionError(err) => {
                     ThresholdEncryptionError::new_err(err.to_string())
                 }
-                Error::InvalidShareNumberParameter(actual) => {
-                    InvalidShareNumberParameter::new_err(actual.to_string())
-                }
                 Error::InvalidDkgStateToDeal => {
                     InvalidDkgStateToDeal::new_err("")
                 }
@@ -111,7 +108,6 @@ impl Debug for FerveoPythonError {
 }
 
 create_exception!(exceptions, ThresholdEncryptionError, PyException);
-create_exception!(exceptions, InvalidShareNumberParameter, PyValueError);
 create_exception!(exceptions, InvalidDkgStateToDeal, PyRuntimeError);
 create_exception!(exceptions, InvalidDkgStateToAggregate, PyRuntimeError);
 create_exception!(exceptions, InvalidDkgStateToVerify, PyRuntimeError);
@@ -595,10 +591,6 @@ pub fn make_ferveo_py_module(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add(
         "ThresholdEncryptionError",
         py.get_type::<ThresholdEncryptionError>(),
-    )?;
-    m.add(
-        "InvalidShareNumberParameter",
-        py.get_type::<InvalidShareNumberParameter>(),
     )?;
     m.add(
         "InvalidDkgStateToDeal",

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -61,7 +61,7 @@ pub struct PubliclyVerifiableDkg<E: Pairing> {
     pub pvss_params: PubliclyVerifiableParams<E>,
     pub validators: ValidatorsMap<E>,
     pub vss: PVSSMap<E>,
-    pub domain: ark_poly::Radix2EvaluationDomain<E::ScalarField>,
+    pub domain: ark_poly::MixedRadixEvaluationDomain<E::ScalarField>,
     pub me: DkgValidator<E>,
     pub state: DkgState<E>,
 }
@@ -84,10 +84,11 @@ impl<E: Pairing> PubliclyVerifiableDkg<E> {
                 dkg_params.shares_num,
             ));
         }
-        let domain = ark_poly::Radix2EvaluationDomain::<E::ScalarField>::new(
-            dkg_params.shares_num as usize,
-        )
-        .expect("unable to construct domain");
+        let domain =
+            ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
+                dkg_params.shares_num as usize,
+            )
+            .expect("unable to construct domain");
 
         // Sort the validators to verify a global ordering
         if !is_sorted(validators) {

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -59,7 +59,7 @@ pub struct PubliclyVerifiableDkg<E: Pairing> {
     pub pvss_params: PubliclyVerifiableParams<E>,
     pub validators: ValidatorsMap<E>,
     pub vss: PVSSMap<E>,
-    pub domain: ark_poly::MixedRadixEvaluationDomain<E::ScalarField>,
+    pub domain: ark_poly::GeneralEvaluationDomain<E::ScalarField>,
     pub me: DkgValidator<E>,
     pub state: DkgState<E>,
 }
@@ -76,11 +76,10 @@ impl<E: Pairing> PubliclyVerifiableDkg<E> {
         dkg_params: &DkgParams,
         me: &Validator<E>,
     ) -> Result<Self> {
-        let domain =
-            ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
-                dkg_params.shares_num as usize,
-            )
-            .expect("unable to construct domain");
+        let domain = ark_poly::GeneralEvaluationDomain::<E::ScalarField>::new(
+            dkg_params.shares_num as usize,
+        )
+        .expect("unable to construct domain");
 
         // Sort the validators to verify a global ordering
         if !is_sorted(validators) {

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -9,10 +9,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 
 use crate::{
-    aggregate,
-    utils::{is_power_of_2, is_sorted},
-    AggregatedPvss, Error, EthereumAddress, PubliclyVerifiableParams,
-    PubliclyVerifiableSS, Pvss, Result, Validator,
+    aggregate, utils::is_sorted, AggregatedPvss, Error, EthereumAddress,
+    PubliclyVerifiableParams, PubliclyVerifiableSS, Pvss, Result, Validator,
 };
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -78,12 +76,6 @@ impl<E: Pairing> PubliclyVerifiableDkg<E> {
         dkg_params: &DkgParams,
         me: &Validator<E>,
     ) -> Result<Self> {
-        // Make sure that the number of shares is a power of 2 for the FFT to work (Radix-2 FFT domain is being used)
-        if !is_power_of_2(dkg_params.shares_num) {
-            return Err(Error::InvalidShareNumberParameter(
-                dkg_params.shares_num,
-            ));
-        }
         let domain =
             ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
                 dkg_params.shares_num as usize,

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -31,10 +31,6 @@ pub enum Error {
     #[error(transparent)]
     ThresholdEncryptionError(#[from] tpke::Error),
 
-    /// Number of shares parameter must be a power of two
-    #[error("Number of shares parameter must be a power of two. Got {0}")]
-    InvalidShareNumberParameter(u32),
-
     /// DKG is not in a valid state to deal PVSS shares
     #[error("Invalid DKG state to deal PVSS shares")]
     InvalidDkgStateToDeal,

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -166,17 +166,17 @@ mod test_dkg_full {
                 })
                 .collect();
 
-        let domain = &dkg
+        let domain_points = &dkg
             .domain
             .elements()
             .take(decryption_shares.len())
             .collect::<Vec<_>>();
-        assert_eq!(domain.len(), decryption_shares.len());
+        assert_eq!(domain_points.len(), decryption_shares.len());
 
         // TODO: Consider refactor this part into tpke::combine_simple and expose it
         //  as a public API in tpke::api
 
-        let lagrange_coeffs = tpke::prepare_combine_simple::<E>(domain);
+        let lagrange_coeffs = tpke::prepare_combine_simple::<E>(domain_points);
         let shared_secret = tpke::share_combine_simple::<E>(
             &decryption_shares,
             &lagrange_coeffs,
@@ -189,89 +189,103 @@ mod test_dkg_full {
     fn test_dkg_simple_tdec() {
         let rng = &mut test_rng();
 
-        let (dkg, validator_keypairs) = setup_dealt_dkg_with_n_validators(3, 4);
-        let msg = "my-msg".as_bytes().to_vec();
-        let aad: &[u8] = "my-aad".as_bytes();
-        let public_key = dkg.public_key();
-        let ciphertext = tpke::encrypt::<E>(
-            SecretBox::new(msg.clone()),
-            aad,
-            &public_key,
-            rng,
-        )
-        .unwrap();
+        // Works for both power of 2 and non-power of 2
+        for shares_num in [4, 7] {
+            let threshold = shares_num / 2 + 1;
+            let (dkg, validator_keypairs) =
+                setup_dealt_dkg_with_n_validators(threshold, shares_num);
+            let msg = "my-msg".as_bytes().to_vec();
+            let aad: &[u8] = "my-aad".as_bytes();
+            let public_key = dkg.public_key();
+            let ciphertext = tpke::encrypt::<E>(
+                SecretBox::new(msg.clone()),
+                aad,
+                &public_key,
+                rng,
+            )
+            .unwrap();
 
-        let (_, _, shared_secret) = make_shared_secret_simple_tdec(
-            &dkg,
-            aad,
-            &ciphertext,
-            &validator_keypairs,
-        );
+            let (_, _, shared_secret) = make_shared_secret_simple_tdec(
+                &dkg,
+                aad,
+                &ciphertext,
+                &validator_keypairs,
+            );
 
-        let plaintext = tpke::decrypt_with_shared_secret(
-            &ciphertext,
-            aad,
-            &shared_secret,
-            &dkg.pvss_params.g_inv(),
-        )
-        .unwrap();
-        assert_eq!(plaintext, msg);
+            let plaintext = tpke::decrypt_with_shared_secret(
+                &ciphertext,
+                aad,
+                &shared_secret,
+                &dkg.pvss_params.g_inv(),
+            )
+            .unwrap();
+            assert_eq!(plaintext, msg);
+        }
     }
 
     #[test]
     fn test_dkg_simple_tdec_precomputed() {
         let rng = &mut test_rng();
 
-        let (dkg, validator_keypairs) = setup_dealt_dkg_with_n_validators(3, 4);
-        let msg = "my-msg".as_bytes().to_vec();
-        let aad: &[u8] = "my-aad".as_bytes();
-        let public_key = dkg.public_key();
-        let ciphertext = tpke::encrypt::<E>(
-            SecretBox::new(msg.clone()),
-            aad,
-            &public_key,
-            rng,
-        )
-        .unwrap();
+        // Works for both power of 2 and non-power of 2
+        for shares_num in [4, 7] {
+            // In precomputed variant, threshold must be equal to shares_num
+            let threshold = shares_num;
+            let (dkg, validator_keypairs) =
+                setup_dealt_dkg_with_n_validators(threshold, shares_num);
+            let msg = "my-msg".as_bytes().to_vec();
+            let aad: &[u8] = "my-aad".as_bytes();
+            let public_key = dkg.public_key();
+            let ciphertext = tpke::encrypt::<E>(
+                SecretBox::new(msg.clone()),
+                aad,
+                &public_key,
+                rng,
+            )
+            .unwrap();
 
-        let pvss_aggregated = aggregate(&dkg.vss);
-        pvss_aggregated.verify_aggregation(&dkg).unwrap();
-        let domain_points = dkg
-            .domain
-            .elements()
-            .take(validator_keypairs.len())
-            .collect::<Vec<_>>();
+            let pvss_aggregated = aggregate(&dkg.vss);
+            pvss_aggregated.verify_aggregation(&dkg).unwrap();
+            let domain_points = dkg
+                .domain
+                .elements()
+                .take(validator_keypairs.len())
+                .collect::<Vec<_>>();
 
-        let decryption_shares: Vec<DecryptionSharePrecomputed<E>> =
-            validator_keypairs
-                .iter()
-                .enumerate()
-                .map(|(validator_address, validator_keypair)| {
-                    pvss_aggregated
-                        .make_decryption_share_simple_precomputed(
-                            &ciphertext,
-                            aad,
-                            &validator_keypair.decryption_key,
-                            validator_address,
-                            &domain_points,
-                            &dkg.pvss_params.g_inv(),
-                        )
-                        .unwrap()
-                })
-                .collect();
+            let decryption_shares: Vec<DecryptionSharePrecomputed<E>> =
+                validator_keypairs
+                    .iter()
+                    .map(|validator_keypair| {
+                        let validator = dkg
+                            .get_validator(&validator_keypair.public_key())
+                            .unwrap();
+                        pvss_aggregated
+                            .make_decryption_share_simple_precomputed(
+                                &ciphertext,
+                                aad,
+                                &validator_keypair.decryption_key,
+                                validator.share_index,
+                                &domain_points,
+                                &dkg.pvss_params.g_inv(),
+                            )
+                            .unwrap()
+                    })
+                    .collect();
+            assert_eq!(domain_points.len(), decryption_shares.len());
 
-        let shared_secret =
-            tpke::share_combine_precomputed::<E>(&decryption_shares);
+            let shared_secret =
+                tpke::share_combine_precomputed::<E>(&decryption_shares);
 
-        // Combination works, let's decrypt
-        let plaintext = tpke::decrypt_with_shared_secret(
-            &ciphertext,
-            aad,
-            &shared_secret,
-            &dkg.pvss_params.g_inv(),
-        )
-        .unwrap();
-        assert_eq!(plaintext, msg);
+            // Combination works, let's decrypt
+            let plaintext = tpke::decrypt_with_shared_secret(
+                &ciphertext,
+                aad,
+                &shared_secret,
+                &dkg.pvss_params.g_inv(),
+            )
+            .unwrap();
+            assert_eq!(plaintext, msg);
+        }
     }
 
     #[test]

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -224,7 +224,7 @@ pub fn do_verify_full<E: Pairing>(
     pvss_encrypted_shares: &[E::G2Affine],
     pvss_params: &PubliclyVerifiableParams<E>,
     validators: &[Validator<E>],
-    domain: &ark_poly::Radix2EvaluationDomain<E::ScalarField>,
+    domain: &ark_poly::MixedRadixEvaluationDomain<E::ScalarField>,
 ) -> bool {
     let mut commitment = batch_to_projective_g1::<E>(pvss_coefficients);
     domain.fft_in_place(&mut commitment);
@@ -256,7 +256,7 @@ pub fn do_verify_aggregation<E: Pairing>(
     pvss_agg_encrypted_shares: &[E::G2Affine],
     pvss_params: &PubliclyVerifiableParams<E>,
     validators: &[Validator<E>],
-    domain: &ark_poly::Radix2EvaluationDomain<E::ScalarField>,
+    domain: &ark_poly::MixedRadixEvaluationDomain<E::ScalarField>,
     vss: &PVSSMap<E>,
 ) -> Result<bool> {
     let is_valid = do_verify_full(

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -71,7 +71,7 @@ impl<E: Pairing> Default for PubliclyVerifiableParams<E> {
 
 /// Secret polynomial used in the PVSS protocol
 /// We wrap this in a struct so that we can zeroize it after use
-struct SecretPolynomial<E: Pairing>(DensePolynomial<E::ScalarField>);
+pub struct SecretPolynomial<E: Pairing>(pub DensePolynomial<E::ScalarField>);
 
 impl<E: Pairing> SecretPolynomial<E> {
     pub fn new(

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -346,6 +346,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         )
         .map_err(|e| e.into())
     }
+
     pub fn make_decryption_share_simple_precomputed(
         &self,
         ciphertext: &Ciphertext<E>,
@@ -358,6 +359,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         let private_key_share = self
             .decrypt_private_key_share(validator_decryption_key, share_index);
 
+        // We use the `prepare_combine_simple` function to precompute the lagrange coefficients
         let lagrange_coeffs = prepare_combine_simple::<E>(domain_points);
 
         DecryptionSharePrecomputed::new(

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -224,7 +224,7 @@ pub fn do_verify_full<E: Pairing>(
     pvss_encrypted_shares: &[E::G2Affine],
     pvss_params: &PubliclyVerifiableParams<E>,
     validators: &[Validator<E>],
-    domain: &ark_poly::MixedRadixEvaluationDomain<E::ScalarField>,
+    domain: &ark_poly::GeneralEvaluationDomain<E::ScalarField>,
 ) -> bool {
     let mut commitment = batch_to_projective_g1::<E>(pvss_coefficients);
     domain.fft_in_place(&mut commitment);
@@ -256,7 +256,7 @@ pub fn do_verify_aggregation<E: Pairing>(
     pvss_agg_encrypted_shares: &[E::G2Affine],
     pvss_params: &PubliclyVerifiableParams<E>,
     validators: &[Validator<E>],
-    domain: &ark_poly::MixedRadixEvaluationDomain<E::ScalarField>,
+    domain: &ark_poly::GeneralEvaluationDomain<E::ScalarField>,
     vss: &PVSSMap<E>,
 ) -> Result<bool> {
     let is_valid = do_verify_full(

--- a/ferveo/src/utils.rs
+++ b/ferveo/src/utils.rs
@@ -1,7 +1,3 @@
-pub fn is_power_of_2(n: u32) -> bool {
-    n != 0 && (n & (n - 1)) == 0
-}
-
 pub fn is_sorted<I>(data: I) -> bool
 where
     I: IntoIterator,

--- a/subproductdomain/src/lib.rs
+++ b/subproductdomain/src/lib.rs
@@ -9,7 +9,7 @@ use ark_ec::{
 use ark_ff::{FftField, Field, Zero};
 use ark_poly::{
     univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain,
-    MixedRadixEvaluationDomain, Polynomial,
+    GeneralEvaluationDomain, Polynomial,
 };
 
 /// Compute a fast multiexp of many scalars times the same base
@@ -342,7 +342,7 @@ pub fn toeplitz_mul<E: Pairing, const NORMALIZE: bool>(
     let m = polynomial.coeffs.len() - 1;
     let size = ark_std::cmp::max(size, m);
 
-    let domain = MixedRadixEvaluationDomain::<E::ScalarField>::new(2 * size)
+    let domain = GeneralEvaluationDomain::<E::ScalarField>::new(2 * size)
         .ok_or_else(|| {
             anyhow::anyhow!("toeplitz multiplication on too large a domain")
         })?;

--- a/subproductdomain/src/lib.rs
+++ b/subproductdomain/src/lib.rs
@@ -9,7 +9,7 @@ use ark_ec::{
 use ark_ff::{FftField, Field, Zero};
 use ark_poly::{
     univariate::DensePolynomial, DenseUVPolynomial, EvaluationDomain,
-    Polynomial, Radix2EvaluationDomain,
+    MixedRadixEvaluationDomain, Polynomial,
 };
 
 /// Compute a fast multiexp of many scalars times the same base
@@ -342,7 +342,7 @@ pub fn toeplitz_mul<E: Pairing, const NORMALIZE: bool>(
     let m = polynomial.coeffs.len() - 1;
     let size = ark_std::cmp::max(size, m);
 
-    let domain = Radix2EvaluationDomain::<E::ScalarField>::new(2 * size)
+    let domain = MixedRadixEvaluationDomain::<E::ScalarField>::new(2 * size)
         .ok_or_else(|| {
             anyhow::anyhow!("toeplitz multiplication on too large a domain")
         })?;

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -161,14 +161,13 @@ mod tests {
         use ark_poly::EvaluationDomain;
         use ark_std::One;
         let fft_domain =
-            ark_poly::MixedRadixEvaluationDomain::<ScalarField>::new(500)
-                .unwrap();
+            ark_poly::GeneralEvaluationDomain::<ScalarField>::new(500).unwrap();
 
         let mut domain = Vec::with_capacity(500);
         let mut point = ScalarField::one();
         for _ in 0..500 {
             domain.push(point);
-            point *= fft_domain.group_gen;
+            point *= fft_domain.group_gen();
         }
 
         let mut lagrange_n_0 = domain.iter().product::<ScalarField>();

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -161,7 +161,8 @@ mod tests {
         use ark_poly::EvaluationDomain;
         use ark_std::One;
         let fft_domain =
-            ark_poly::Radix2EvaluationDomain::<ScalarField>::new(500).unwrap();
+            ark_poly::MixedRadixEvaluationDomain::<ScalarField>::new(500)
+                .unwrap();
 
         let mut domain = Vec::with_capacity(500);
         let mut point = ScalarField::one();

--- a/tpke/src/decryption.rs
+++ b/tpke/src/decryption.rs
@@ -166,7 +166,6 @@ impl<E: Pairing> DecryptionSharePrecomputed<E> {
         g_inv: &E::G1Prepared,
     ) -> Result<Self> {
         check_ciphertext_validity::<E>(ciphertext, aad, g_inv)?;
-
         Self::create_unchecked(
             validator_index,
             validator_decryption_key,

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -94,7 +94,7 @@ pub mod test_common {
             DensePolynomial::<E::ScalarField>::rand(threshold - 1, rng);
         // Domain, or omega Ω
         let fft_domain =
-            ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
+            ark_poly::GeneralEvaluationDomain::<E::ScalarField>::new(
                 shares_num,
             )
             .unwrap();
@@ -123,9 +123,9 @@ pub mod test_common {
 
         for _ in 0..shares_num {
             domain_points.push(point); // 1, t, t^2, t^3, ...; where t is a scalar generator fft_domain.group_gen
-            point *= fft_domain.group_gen;
+            point *= fft_domain.group_gen();
             domain_points_inv.push(point_inv);
-            point_inv *= fft_domain.group_gen_inv;
+            point_inv *= fft_domain.group_gen_inv();
         }
 
         let mut private_contexts = vec![];
@@ -195,7 +195,7 @@ pub mod test_common {
             DensePolynomial::<E::ScalarField>::rand(threshold - 1, rng);
         // Domain, or omega Ω
         let fft_domain =
-            ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
+            ark_poly::GeneralEvaluationDomain::<E::ScalarField>::new(
                 shares_num,
             )
             .unwrap();

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -94,8 +94,10 @@ pub mod test_common {
             DensePolynomial::<E::ScalarField>::rand(threshold - 1, rng);
         // Domain, or omega Ω
         let fft_domain =
-            ark_poly::Radix2EvaluationDomain::<E::ScalarField>::new(shares_num)
-                .unwrap();
+            ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
+                shares_num,
+            )
+            .unwrap();
         // `evals` are evaluations of the polynomial f over the domain, omega: f(ω_j) for ω_j in Ω
         let evals = threshold_poly.evaluate_over_domain_by_ref(fft_domain);
 
@@ -193,8 +195,10 @@ pub mod test_common {
             DensePolynomial::<E::ScalarField>::rand(threshold - 1, rng);
         // Domain, or omega Ω
         let fft_domain =
-            ark_poly::Radix2EvaluationDomain::<E::ScalarField>::new(shares_num)
-                .unwrap();
+            ark_poly::MixedRadixEvaluationDomain::<E::ScalarField>::new(
+                shares_num,
+            )
+            .unwrap();
         // `evals` are evaluations of the polynomial f over the domain, omega: f(ω_j) for ω_j in Ω
         let evals = threshold_poly.evaluate_over_domain_by_ref(fft_domain);
 


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Adds benchmarks to compare the performance of `MixedRadixEvaluationDomain` (without constraints on the number of coefficients) and `Radix2EvaluationDomain` (number of coefficients must be a power of two)
- Replaces usage of `Radix2EvaluationDomain` with [`GeneralEvaluationDomain`](https://docs.rs/ark-poly/latest/ark_poly/domain/general/enum.GeneralEvaluationDomain.html#) (automatically select domain size) in `ferveo`

**Issues fixed/closed:**
- Fixes #130

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- Please see benchmarking results attached
- Based on https://github.com/nucypher/ferveo/pull/136
- Fixed a bug where `Dkg` in `ferveo::api` is using an incorrect number of domain points to create a precomputed share


<details>
<summary><b>Benchmarking results</b></summary>

![lines](https://github.com/nucypher/ferveo/assets/39299780/16f248f4-0efb-45e9-9e68-a9618c4fb40a)
![violin](https://github.com/nucypher/ferveo/assets/39299780/94530208-d96e-4adc-8da6-7543e32372d1)
</details>
