### PR TITLE
Use static arrays in `FerveoPublicKey` serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,6 @@ dependencies = [
  "bincode",
  "generic-array",
  "rand 0.8.5",
- "rand_core 0.6.4",
  "serde",
  "serde_with",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "bincode",
+ "generic-array",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",

--- a/ferveo-common/Cargo.toml
+++ b/ferveo-common/Cargo.toml
@@ -13,7 +13,6 @@ ark-std = "0.4"
 bincode = "1.3.3"
 generic-array = "0.14.7"
 rand = "0.8"
-rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "2.2.0"
 

--- a/ferveo-common/Cargo.toml
+++ b/ferveo-common/Cargo.toml
@@ -11,6 +11,7 @@ ark-ec = "0.4"
 ark-serialize = { version = "0.4", features = ["derive"] }
 ark-std = "0.4"
 bincode = "1.3.3"
+generic-array = "0.14.7"
 rand = "0.8"
 rand_core = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/ferveo-common/src/lib.rs
+++ b/ferveo-common/src/lib.rs
@@ -1,5 +1,36 @@
 pub mod keypair;
 pub mod serialization;
 
+use std::{fmt, fmt::Formatter};
+
 pub use keypair::*;
 pub use serialization::*;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidByteLength(usize, usize),
+    SerializationError(ark_serialize::SerializationError),
+    InvalidSeedLength(usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidByteLength(expected, actual) => {
+                write!(
+                    f,
+                    "Invalid byte length: expected {}, actual {}",
+                    expected, actual
+                )
+            }
+            Error::SerializationError(e) => {
+                write!(f, "Serialization error: {}", e)
+            }
+            Error::InvalidSeedLength(len) => {
+                write!(f, "Invalid seed length: {}", len)
+            }
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, Error>;

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -36,6 +36,9 @@ class FerveoPublicKey:
     def __hash__(self) -> int:
         ...
 
+    def __richcmp__(self, other: FerveoPublicKey, op: int) -> bool:
+        ...
+
 
 class Validator:
 

--- a/ferveo-python/test/test_serialization.py
+++ b/ferveo-python/test/test_serialization.py
@@ -4,6 +4,7 @@ from ferveo_py import (
     Dkg,
     DkgPublicKey,
     FerveoPublicKey,
+    SharedSecret,
 )
 
 
@@ -35,7 +36,8 @@ def make_dkg_public_key():
 
 
 def make_shared_secret():
-    # TODO: implement this
+    # TODO: Implement this
+    # SharedSecret.from_bytes(os.urandom(584))
     pass
 
 
@@ -44,27 +46,34 @@ def make_pk():
 
 
 # def test_shared_secret_serialization():
-#     shared_secret = create_shared_secret_instance()
+#     shared_secret = make_shared_secret()
 #     serialized = bytes(shared_secret)
 #     deserialized = SharedSecret.from_bytes(serialized)
-#     TODO: Implement comparison
-#     assert shared_secret == deserialized
+#     # TODO: Implement __richcmp__
+#     # assert shared_secret == deserialized
+#     assert serialized == bytes(deserialized)
 
 def test_keypair_serialization():
     keypair = Keypair.random()
     serialized = bytes(keypair)
     deserialized = Keypair.from_bytes(serialized)
-    # TODO: Implement comparison
-    # assert keypair == deserialized
+    # TODO: Implement __richcmp__
+    # assert serialized == deserialized
+    assert serialized == bytes(deserialized)
 
 
 def test_dkg_public_key_serialization():
     dkg_pk = make_dkg_public_key()
     serialized = bytes(dkg_pk)
+    deserialized = DkgPublicKey.from_bytes(serialized)
+    # TODO: Implement __richcmp__
+    assert serialized == bytes(deserialized)
     assert len(serialized) == DkgPublicKey.serialized_size()
 
 
 def test_public_key_serialization():
     pk = make_pk()
     serialized = bytes(pk)
+    deserialized = FerveoPublicKey.from_bytes(serialized)
+    assert pk == deserialized
     assert len(serialized) == FerveoPublicKey.serialized_size()

--- a/ferveo-python/test/test_serialization.py
+++ b/ferveo-python/test/test_serialization.py
@@ -2,7 +2,8 @@ from ferveo_py import (
     Keypair,
     Validator,
     Dkg,
-    DkgPublicKey
+    DkgPublicKey,
+    FerveoPublicKey,
 )
 
 
@@ -38,6 +39,10 @@ def make_shared_secret():
     pass
 
 
+def make_pk():
+    return Keypair.random().public_key()
+
+
 # def test_shared_secret_serialization():
 #     shared_secret = create_shared_secret_instance()
 #     serialized = bytes(shared_secret)
@@ -57,3 +62,9 @@ def test_dkg_public_key_serialization():
     dkg_pk = make_dkg_public_key()
     serialized = bytes(dkg_pk)
     assert len(serialized) == DkgPublicKey.serialized_size()
+
+
+def test_dkg_public_key_serialization():
+    pk = make_pk()
+    serialized = bytes(pk)
+    assert len(serialized) == FerveoPublicKey.serialized_size()

--- a/ferveo-python/test/test_serialization.py
+++ b/ferveo-python/test/test_serialization.py
@@ -64,7 +64,7 @@ def test_dkg_public_key_serialization():
     assert len(serialized) == DkgPublicKey.serialized_size()
 
 
-def test_dkg_public_key_serialization():
+def test_public_key_serialization():
     pk = make_pk()
     serialized = bytes(pk)
     assert len(serialized) == FerveoPublicKey.serialized_size()

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -84,7 +84,12 @@ impl DkgPublicKey {
     pub fn from_bytes(bytes: &[u8]) -> Result<DkgPublicKey> {
         let bytes =
             GenericArray::<u8, U48>::from_exact_iter(bytes.iter().cloned())
-                .ok_or(Error::InvalidByteLength(48, bytes.len()))?;
+                .ok_or_else(|| {
+                    Error::InvalidByteLength(
+                        Self::serialized_size(),
+                        bytes.len(),
+                    )
+                })?;
         from_bytes(&bytes).map(DkgPublicKey)
     }
 
@@ -198,7 +203,7 @@ impl AggregatedTranscript {
         shares_num: u32,
         messages: &[ValidatorMessage],
     ) -> Result<bool> {
-        let pvss_params = crate::pvss::PubliclyVerifiableParams::<E>::default();
+        let pvss_params = PubliclyVerifiableParams::<E>::default();
         let domain = Radix2EvaluationDomain::<Fr>::new(shares_num as usize)
             .expect("Unable to construct an evaluation domain");
 

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -363,6 +363,14 @@ mod test_ferveo_api {
     }
 
     #[test]
+    fn test_dkg_pk_serialization() {
+        let dkg_pk = DkgPublicKey::random();
+        let serialized = dkg_pk.to_bytes().unwrap();
+        let deserialized = DkgPublicKey::from_bytes(&serialized).unwrap();
+        assert_eq!(dkg_pk, deserialized);
+    }
+
+    #[test]
     fn test_server_api_tdec_precomputed() {
         let rng = &mut StdRng::seed_from_u64(0);
 

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -172,17 +172,6 @@ where
     }
 }
 
-// TODO: Consider implementing macros to generate following methods
-
-// fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
-//     richcmp(self, other, op)
-// }
-
-// fn __hash__(&self) -> PyResult<isize> {
-//     let bytes = self.0.to_bytes()?;
-//     hash(stringify!($struct_name), &bytes)
-// }
-
 macro_rules! generate_bytes_serialization {
     ($struct_name:ident) => {
         #[pymethods]
@@ -326,6 +315,7 @@ generate_boxed_bytes_serialization!(FerveoPublicKey, InnerPublicKey);
 
 #[pymethods]
 impl FerveoPublicKey {
+    // We implement `__richcmp__` because FerveoPublicKeys must be sortable in some cases
     fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
         richcmp(self, other, op)
     }
@@ -857,7 +847,6 @@ mod test_ferveo_python {
 
         let shared_secret = combine_decryption_shares_simple(decryption_shares);
 
-        // TODO: Fails because of a bad shared secret
         let plaintext =
             decrypt_with_shared_secret(&ciphertext, aad, &shared_secret)
                 .unwrap();


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Implement static array serialization shortening serialized size of `FerveoPublicKey` from 104 bytes to 96 bytes

**Issues fixed/closed:**
- Related to: https://github.com/nucypher/nucypher-contracts/pull/77

**Why it's needed:**
- Reduce the on-chain footprint of DKG participants

**Notes for reviewers:**
- Similar to previous changes to `DkgPublicKey` serialization: https://github.com/nucypher/ferveo/pull/128
