### PR TITLE
Expose `FerveoVariant` from bindings

### DIFF
--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -15,6 +15,7 @@ from .ferveo_py import (
     DkgPublicKey,
     SharedSecret,
     ValidatorMessage,
+    FerveoVariant,
     ThresholdEncryptionError,
     InvalidShareNumberParameter,
     InvalidDkgStateToDeal,
@@ -32,4 +33,5 @@ from .ferveo_py import (
     ValidatorsNotSorted,
     ValidatorPublicKeyMismatch,
     SerializationError,
+    InvalidVariant,
 )

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -173,6 +173,14 @@ class SharedSecret:
         ...
 
 
+class FerveoVariant:
+    @staticmethod
+    def simple() -> str: ...
+
+    @staticmethod
+    def precomputed() -> str: ...
+
+
 def encrypt(message: bytes, add: bytes, dkg_public_key: DkgPublicKey) -> Ciphertext:
     ...
 
@@ -262,4 +270,8 @@ class ValidatorPublicKeyMismatch(Exception):
 
 
 class SerializationError(Exception):
+    pass
+
+
+class InvalidVariant(Exception):
     pass

--- a/ferveo-python/test/test_serialization.py
+++ b/ferveo-python/test/test_serialization.py
@@ -4,6 +4,7 @@ from ferveo_py import (
     Dkg,
     DkgPublicKey,
     FerveoPublicKey,
+    FerveoVariant,
     SharedSecret,
 )
 
@@ -77,3 +78,8 @@ def test_public_key_serialization():
     deserialized = FerveoPublicKey.from_bytes(serialized)
     assert pk == deserialized
     assert len(serialized) == FerveoPublicKey.serialized_size()
+
+
+def test_ferveo_variant_serialization():
+    assert FerveoVariant.precomputed() == "FerveoVariant::Precomputed"
+    assert FerveoVariant.simple() == "FerveoVariant::Simple"

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{fmt, io};
 
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -67,6 +67,38 @@ pub fn decrypt_with_shared_secret(
         &dkg_public_params.g1_inv,
     )
     .map_err(Error::from)
+}
+
+/// The ferveo variant to use for the decryption share derivation.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Copy, Clone)]
+pub enum FerveoVariant {
+    /// The simple variant requires m of n shares to decrypt
+    Simple,
+    /// The precomputed variant requires n of n shares to decrypt
+    Precomputed,
+}
+
+impl fmt::Display for FerveoVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FerveoVariant {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FerveoVariant::Simple => "FerveoVariant::Simple",
+            FerveoVariant::Precomputed => "FerveoVariant::Precomputed",
+        }
+    }
+
+    pub fn from_string(s: &str) -> Result<Self> {
+        match s {
+            "FerveoVariant::Simple" => Ok(FerveoVariant::Simple),
+            "FerveoVariant::Precomputed" => Ok(FerveoVariant::Precomputed),
+            _ => Err(Error::InvalidVariant(s.to_string())),
+        }
+    }
 }
 
 #[serde_as]

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -161,6 +161,22 @@ macro_rules! generate_common_methods {
     };
 }
 
+#[wasm_bindgen]
+pub struct FerveoVariant {}
+
+#[wasm_bindgen]
+impl FerveoVariant {
+    #[wasm_bindgen(js_name = "precomputed", getter)]
+    pub fn precomputed() -> String {
+        api::FerveoVariant::Precomputed.as_str().to_string()
+    }
+
+    #[wasm_bindgen(js_name = "simple", getter)]
+    pub fn simple() -> String {
+        api::FerveoVariant::Simple.as_str().to_string()
+    }
+}
+
 #[derive(TryFromJsValue)]
 #[wasm_bindgen]
 #[derive(Clone, Debug, derive_more::AsRef, derive_more::From)]

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -101,6 +101,9 @@ pub enum Error {
 
     #[error("Invalid byte length. Expected {0}, got {1}")]
     InvalidByteLength(usize, usize),
+
+    #[error("Invalid variant: {0}")]
+    InvalidVariant(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Exposes `FerveoVariant` in Python and WASM bindings

**Issues fixed/closed:**
- Fixes: https://github.com/nucypher/ferveo/issues/116

**Why it's needed:**
- Simplifies handling of different Ferveo variants by exposing a shared type

**Notes for reviewers:**
- Based on https://github.com/nucypher/ferveo/pull/136
- Downstream changes:
  - https://github.com/nucypher/nucypher/issues/3168
  - https://github.com/nucypher/nucypher-ts/issues/236 
