### PR TITLE
Revamping Ferveo Ciphertexts (breaking changes ⚠️ )

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A preprint paper describing the construction of Ferveo and the novel cryptosyste
 
 ## Build
 
-A Rust toolchain with version `>= 1.65.0` is required. In the future, Ferveo will target the `stable` toolchain.
+A Rust toolchain with version `>= 1.67.0` is required. In the future, Ferveo will target the `stable` toolchain.
 Installation via [rustup](https://rustup.rs/) is recommended.
 
 Run `cargo build --release` to build.

--- a/ferveo-common/src/lib.rs
+++ b/ferveo-common/src/lib.rs
@@ -19,15 +19,14 @@ impl fmt::Display for Error {
             Error::InvalidByteLength(expected, actual) => {
                 write!(
                     f,
-                    "Invalid byte length: expected {}, actual {}",
-                    expected, actual
+                    "Invalid byte length: expected {expected}, actual {actual}"
                 )
             }
             Error::SerializationError(e) => {
-                write!(f, "Serialization error: {}", e)
+                write!(f, "Serialization error: {e}")
             }
             Error::InvalidSeedLength(len) => {
-                write!(f, "Invalid seed length: {}", len)
+                write!(f, "Invalid seed length: {len}")
             }
         }
     }

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -65,14 +65,12 @@ impl From<FerveoPythonError> for PyErr {
                     expected,
                     actual,
                 ) => InsufficientTranscriptsForAggregate::new_err(format!(
-                    "expected: {}, actual: {}",
-                    expected, actual
+                    "expected: {expected}, actual: {actual}"
                 )),
                 Error::InvalidDkgPublicKey => InvalidDkgPublicKey::new_err(""),
                 Error::InsufficientValidators(expected, actual) => {
                     InsufficientValidators::new_err(format!(
-                        "expected: {}, actual: {}",
-                        expected, actual
+                        "expected: {expected}, actual: {actual}"
                     ))
                 }
                 Error::InvalidTranscriptAggregate => {
@@ -90,8 +88,7 @@ impl From<FerveoPythonError> for PyErr {
                 }
                 Error::InvalidByteLength(expected, actual) => {
                     InvalidByteLength::new_err(format!(
-                        "expected: {}, actual: {}",
-                        expected, actual
+                        "expected: {expected}, actual: {actual}"
                     ))
                 }
                 Error::InvalidVariant(variant) => {

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -30,7 +30,7 @@ pub fn set_panic_hook() {
 }
 
 pub fn map_js_err<T: fmt::Display>(err: T) -> Error {
-    Error::new(&format!("{}", err))
+    Error::new(&format!("{err}"))
 }
 
 pub fn to_js_bytes<T: ToBytes>(t: &T) -> Result<Vec<u8>, Error> {
@@ -577,7 +577,7 @@ pub mod test_common {
     }
 
     pub fn gen_address(i: usize) -> EthereumAddress {
-        EthereumAddress::from_string(&format!("0x{:040}", i)).unwrap()
+        EthereumAddress::from_string(&format!("0x{i:040}")).unwrap()
     }
 
     pub fn gen_validator(i: usize, keypair: &Keypair) -> Validator {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "default"
-channel = "1.65.0"
+channel = "1.67.0"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -388,8 +388,7 @@ pub fn bench_ciphertext_validity_checks(c: &mut Criterion) {
             let mut rng = rng.clone();
             let setup = SetupFast::new(shares_num, msg_size, &mut rng);
             move || {
-                black_box(check_ciphertext_validity(
-                    &setup.shared.ciphertext,
+                black_box(setup.shared.ciphertext.check(
                     &setup.shared.aad,
                     &setup.contexts[0].setup_params.g_inv,
                 ))

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -244,7 +244,11 @@ mod tests {
         let plaintext =
             decrypt_symmetric(&ciphertext, aad, &privkey, g_inv).unwrap();
 
-        assert_eq!(msg, plaintext)
+        assert_eq!(msg, plaintext);
+
+        let bad: &[u8] = "bad-aad".as_bytes();
+
+        assert!(decrypt_symmetric(&ciphertext, bad, &privkey, g_inv).is_err());
     }
 
     #[test]

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -32,22 +32,32 @@ pub struct Ciphertext<E: Pairing> {
 }
 
 impl<E: Pairing> Ciphertext<E> {
-    pub fn check(&self, g_inv: &E::G1Prepared) -> Result<bool> {
-        let hash_g2 = E::G2Prepared::from(self.construct_tag_hash()?);
+    pub fn check(&self, aad: &[u8], g_inv: &E::G1Prepared) -> Result<bool> {
+        // Implements a variant of the check in section 4.4.2 of the Ferveo paper:
+        //     'TPKE.CheckCiphertextValidity(U,W,aad)'
+        // See: https://eprint.iacr.org/2022/898.pdf
+        // See: https://nikkolasg.github.io/ferveo/tpke.html#to-validate-ciphertext-for-ind-cca2-security
 
-        Ok(E::multi_pairing(
+        // H_G2(U, sym_ctxt, aad)
+        let hash_g2 = E::G2Prepared::from(construct_tag_hash::<E>(
+            self.commitment,
+            &self.ciphertext[..],
+            aad,
+        )?);
+
+        let is_ciphertext_valid = E::multi_pairing(
+            // e(U, H_G2(U, sym_ctxt, aad)) = e(G, W) ==>
+            // e(U, H_G2(U, sym_ctxt, aad)) * e(G_inv, W) = 1
             [self.commitment.into(), g_inv.to_owned()],
             [hash_g2, self.auth_tag.into()],
         )
-        .0 == E::TargetField::one())
-    }
+        .0 == E::TargetField::one();
 
-    fn construct_tag_hash(&self) -> Result<E::G2Affine> {
-        let mut hash_input = Vec::<u8>::new();
-        self.commitment.serialize_compressed(&mut hash_input)?;
-        hash_input.extend_from_slice(&self.ciphertext);
-
-        hash_to_g2(&hash_input)
+        if is_ciphertext_valid {
+            Ok(true)
+        } else {
+            Err(Error::CiphertextVerificationFailed)
+        }
     }
 
     pub fn serialized_length(&self) -> usize {
@@ -95,42 +105,13 @@ pub fn encrypt<E: Pairing>(
     })
 }
 
-/// Implements the check section 4.4.2 of the Ferveo paper, 'TPKE.CheckCiphertextValidity(U,W,aad)'
-/// See: https://eprint.iacr.org/2022/898.pdf
-/// See: https://nikkolasg.github.io/ferveo/tpke.html#to-validate-ciphertext-for-ind-cca2-security
-pub fn check_ciphertext_validity<E: Pairing>(
-    c: &Ciphertext<E>,
-    aad: &[u8],
-    g_inv: &E::G1Prepared,
-) -> Result<()> {
-    // H_G2(U, aad)
-    let hash_g2 = E::G2Prepared::from(construct_tag_hash::<E>(
-        c.commitment,
-        &c.ciphertext[..],
-        aad,
-    )?);
-
-    let is_ciphertext_valid = E::multi_pairing(
-        // e(U, H_G2(U, aad)) = e(G, W)
-        [c.commitment.into(), g_inv.to_owned()],
-        [hash_g2, c.auth_tag.into()],
-    )
-    .0 == E::TargetField::one();
-
-    if is_ciphertext_valid {
-        Ok(())
-    } else {
-        Err(Error::CiphertextVerificationFailed)
-    }
-}
-
 pub fn decrypt_symmetric<E: Pairing>(
     ciphertext: &Ciphertext<E>,
     aad: &[u8],
     private_key: &E::G2Affine,
     g_inv: &E::G1Prepared,
 ) -> Result<Vec<u8>> {
-    check_ciphertext_validity(ciphertext, aad, g_inv)?;
+    ciphertext.check(aad, g_inv)?;
     let shared_secret = E::pairing(
         E::G1Prepared::from(ciphertext.commitment),
         E::G2Prepared::from(*private_key),
@@ -161,7 +142,7 @@ pub fn decrypt_with_shared_secret<E: Pairing>(
     shared_secret: &SharedSecret<E>,
     g_inv: &E::G1Prepared,
 ) -> Result<Vec<u8>> {
-    check_ciphertext_validity(ciphertext, aad, g_inv)?;
+    ciphertext.check(aad, g_inv)?;
     decrypt_with_shared_secret_unchecked(ciphertext, shared_secret)
 }
 
@@ -267,14 +248,14 @@ mod tests {
             encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
 
         // So far, the ciphertext is valid
-        assert!(check_ciphertext_validity(&ciphertext, aad, &g_inv).is_ok());
+        assert!(ciphertext.check(aad, &g_inv).is_ok());
 
         // Malformed the ciphertext
         ciphertext.ciphertext[0] += 1;
-        assert!(check_ciphertext_validity(&ciphertext, aad, &g_inv).is_err());
+        assert!(ciphertext.check(aad, &g_inv).is_err());
 
         // Malformed the AAD
         let aad = "bad aad".as_bytes();
-        assert!(check_ciphertext_validity(&ciphertext, aad, &g_inv).is_err());
+        assert!(ciphertext.check(aad, &g_inv).is_err());
     }
 }

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -2,7 +2,7 @@ use std::ops::Mul;
 
 use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_ff::{One, UniformRand};
-use ark_serialize::{CanonicalSerialize, Compress};
+use ark_serialize::CanonicalSerialize;
 use chacha20poly1305::{
     aead::{generic_array::GenericArray, Aead, KeyInit, Payload},
     ChaCha20Poly1305,
@@ -59,12 +59,6 @@ impl<E: Pairing> Ciphertext<E> {
         } else {
             Err(Error::CiphertextVerificationFailed)
         }
-    }
-
-    pub fn serialized_length(&self) -> usize {
-        self.commitment.serialized_size(Compress::No)
-            + self.auth_tag.serialized_size(Compress::No)
-            + self.ciphertext.len()
     }
 }
 

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -3,9 +3,9 @@ use std::ops::Mul;
 use ark_ec::{pairing::Pairing, CurveGroup};
 
 use crate::{
-    check_ciphertext_validity, prepare_combine_simple, BlindedKeyShare,
-    Ciphertext, DecryptionShareFast, DecryptionSharePrecomputed,
-    DecryptionShareSimple, PrivateKeyShare, PublicKeyShare, Result,
+    prepare_combine_simple, BlindedKeyShare, Ciphertext, DecryptionShareFast,
+    DecryptionSharePrecomputed, DecryptionShareSimple, PrivateKeyShare,
+    PublicKeyShare, Result,
 };
 
 #[derive(Clone, Debug)]
@@ -51,11 +51,7 @@ impl<E: Pairing> PrivateDecryptionContextFast<E> {
         ciphertext: &Ciphertext<E>,
         aad: &[u8],
     ) -> Result<DecryptionShareFast<E>> {
-        check_ciphertext_validity::<E>(
-            ciphertext,
-            aad,
-            &self.setup_params.g_inv,
-        )?;
+        ciphertext.check(aad, &self.setup_params.g_inv)?;
 
         let decryption_share = ciphertext
             .commitment

--- a/tpke/src/decryption.rs
+++ b/tpke/src/decryption.rs
@@ -9,8 +9,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 
 use crate::{
-    check_ciphertext_validity, generate_random, Ciphertext, PrivateKeyShare,
-    PublicDecryptionContextFast, PublicDecryptionContextSimple, Result,
+    generate_random, Ciphertext, PrivateKeyShare, PublicDecryptionContextFast,
+    PublicDecryptionContextSimple, Result,
 };
 
 #[serde_as]
@@ -94,7 +94,7 @@ impl<E: Pairing> DecryptionShareSimple<E> {
         aad: &[u8],
         g_inv: &E::G1Prepared,
     ) -> Result<Self> {
-        check_ciphertext_validity::<E>(ciphertext, aad, g_inv)?;
+        ciphertext.check(aad, g_inv)?;
         Self::create_unchecked(
             validator_decryption_key,
             private_key_share,
@@ -165,7 +165,7 @@ impl<E: Pairing> DecryptionSharePrecomputed<E> {
         lagrange_coeff: &E::ScalarField,
         g_inv: &E::G1Prepared,
     ) -> Result<Self> {
-        check_ciphertext_validity::<E>(ciphertext, aad, g_inv)?;
+        ciphertext.check(aad, g_inv)?;
         Self::create_unchecked(
             validator_index,
             validator_decryption_key,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Some of the changes introduced by this PR, all of them related with how ciphertexts are produced and used:
* Actually use the AAD input of the AEAD API of Chacha20Poly1305
    * Closes #146 
* Decouple the bulk of symmetric ciphertext from validation; instead just use the hash. This allows to have a small (and also constant!) decryption request. 
    * Closes #147 
    * Implies changes in nucypher-core and nucypher (TBD)
* Refactor `Ciphertext` implementation.
    * Fixes #144 
    * Remove unused & incorrect ciphertext length method (see #145 )

Apart from this, bumps MSRV to 1.67.0, and associated clippy changes.

**Why it's needed:**
@jMyles and @KPrasch identified an important limitation of current ciphertexts and TDec requests construction. Essentially, the TDec request included the full ciphertext, which implies a big overhead even for relatively small media files (e.g. short audio clips). The main goal of this PR was to decouple the bulk of symmetric ciphertext from the validation procedure, using a  hash instead. This enables very small TDec requests ( see #147). In the nucypher side, will allow to close https://github.com/nucypher/nucypher/issues/3176 via https://github.com/nucypher/nucypher/pull/3194

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
