### PR TITLE
Update `Ciphertext` bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A preprint paper describing the construction of Ferveo and the novel cryptosyste
 
 ## Build
 
-A Rust toolchain with version `>= 1.65.0` is required. In the future, Ferveo will target the `stable` toolchain.
+A Rust toolchain with version `>= 1.67.0` is required. In the future, Ferveo will target the `stable` toolchain.
 Installation via [rustup](https://rustup.rs/) is recommended.
 
 Run `cargo build --release` to build.

--- a/ferveo-common/src/lib.rs
+++ b/ferveo-common/src/lib.rs
@@ -19,15 +19,14 @@ impl fmt::Display for Error {
             Error::InvalidByteLength(expected, actual) => {
                 write!(
                     f,
-                    "Invalid byte length: expected {}, actual {}",
-                    expected, actual
+                    "Invalid byte length: expected {expected}, actual {actual}"
                 )
             }
             Error::SerializationError(e) => {
-                write!(f, "Serialization error: {}", e)
+                write!(f, "Serialization error: {e}")
             }
             Error::InvalidSeedLength(len) => {
-                write!(f, "Invalid seed length: {}", len)
+                write!(f, "Invalid seed length: {len}")
             }
         }
     }

--- a/ferveo-python/examples/server_api_precomputed.py
+++ b/ferveo-python/examples/server_api_precomputed.py
@@ -82,7 +82,7 @@ for validator, validator_keypair in zip(validators, validator_keypairs):
 
     # Create a decryption share for the ciphertext
     decryption_share = aggregate.create_decryption_share_precomputed(
-        dkg, ciphertext, aad, validator_keypair
+        dkg, ciphertext.header, aad, validator_keypair
     )
     decryption_shares.append(decryption_share)
 

--- a/ferveo-python/examples/server_api_simple.py
+++ b/ferveo-python/examples/server_api_simple.py
@@ -85,7 +85,7 @@ for validator, validator_keypair in zip(validators, validator_keypairs):
 
     # Create a decryption share for the ciphertext
     decryption_share = aggregate.create_decryption_share_simple(
-        dkg, ciphertext, aad, validator_keypair
+        dkg, ciphertext.header, aad, validator_keypair
     )
     decryption_shares.append(decryption_share)
 

--- a/ferveo-python/ferveo/__init__.py
+++ b/ferveo-python/ferveo/__init__.py
@@ -9,6 +9,7 @@ from ._ferveo import (
     Transcript,
     Dkg,
     Ciphertext,
+    CiphertextHeader,
     DecryptionShareSimple,
     DecryptionSharePrecomputed,
     AggregatedTranscript,

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -133,7 +133,7 @@ class Ciphertext:
 @final
 class CiphertextHeader:
     @staticmethod
-    def from_bytes(data: bytes) -> Ciphertext:
+    def from_bytes(data: bytes) -> CiphertextHeader:
         ...
 
     def __bytes__(self) -> bytes:

--- a/ferveo-python/ferveo/__init__.pyi
+++ b/ferveo-python/ferveo/__init__.pyi
@@ -119,6 +119,19 @@ class Dkg:
 
 @final
 class Ciphertext:
+    header: CiphertextHeader
+    payload: bytes
+
+    @staticmethod
+    def from_bytes(data: bytes) -> Ciphertext:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+
+@final
+class CiphertextHeader:
     @staticmethod
     def from_bytes(data: bytes) -> Ciphertext:
         ...
@@ -159,7 +172,7 @@ class AggregatedTranscript:
     def create_decryption_share_simple(
             self,
             dkg: Dkg,
-            ciphertext: Ciphertext,
+            ciphertext_header: CiphertextHeader,
             aad: bytes,
             validator_keypair: Keypair
     ) -> DecryptionShareSimple:
@@ -168,7 +181,7 @@ class AggregatedTranscript:
     def create_decryption_share_precomputed(
             self,
             dkg: Dkg,
-            ciphertext: Ciphertext,
+            ciphertext_header: CiphertextHeader,
             aad: bytes,
             validator_keypair: Keypair
     ) -> DecryptionSharePrecomputed:

--- a/ferveo-python/test/test_ferveo.py
+++ b/ferveo-python/test/test_ferveo.py
@@ -91,7 +91,7 @@ def scenario_for_variant(variant: FerveoVariant, shares_num, threshold, shares_t
         assert pvss_aggregated.verify(shares_num, messages)
 
         decryption_share = decryption_share_for_variant(variant, pvss_aggregated)(
-            dkg, ciphertext, aad, validator_keypair
+            dkg, ciphertext.header, aad, validator_keypair
         )
         decryption_shares.append(decryption_share)
 

--- a/ferveo-wasm/examples/node/src/main.test.ts
+++ b/ferveo-wasm/examples/node/src/main.test.ts
@@ -27,11 +27,11 @@ function setupTest() {
   const sharesNum = 4;
   const threshold = Math.floor((sharesNum * 2) / 3);
 
-  const validator_keypairs: Keypair[] = [];
+  const validatorKeypairs: Keypair[] = [];
   const validators: Validator[] = [];
   for (let i = 0; i < sharesNum; i++) {
     const keypair = Keypair.random();
-    validator_keypairs.push(keypair);
+    validatorKeypairs.push(keypair);
     const validator = new Validator(genEthAddr(i), keypair.publicKey);
     validators.push(validator);
   }
@@ -66,7 +66,7 @@ function setupTest() {
     tau,
     sharesNum,
     threshold,
-    validatorKeypairs: validator_keypairs,
+    validatorKeypairs,
     validators,
     dkg,
     messages,
@@ -103,7 +103,7 @@ describe("ferveo-wasm", () => {
 
       const decryptionShare = aggregate.createDecryptionShareSimple(
         dkg,
-        ciphertext,
+        ciphertext.header,
         aad,
         keypair
       );
@@ -150,7 +150,7 @@ describe("ferveo-wasm", () => {
 
       const decryptionShare = aggregate.createDecryptionSharePrecomputed(
         dkg,
-        ciphertext,
+        ciphertext.header,
         aad,
         keypair
       );

--- a/ferveo-wasm/tests/node.rs
+++ b/ferveo-wasm/tests/node.rs
@@ -125,7 +125,7 @@ fn tdec_simple() {
             aggregate
                 .create_decryption_share_simple(
                     &dkg,
-                    &ciphertext,
+                    &ciphertext.header().unwrap(),
                     &aad,
                     &keypair,
                 )
@@ -179,7 +179,7 @@ fn tdec_precomputed() {
             aggregate
                 .create_decryption_share_precomputed(
                     &dkg,
-                    &ciphertext,
+                    &ciphertext.header().unwrap(),
                     &aad,
                     &keypair,
                 )

--- a/ferveo/benches/benchmarks/validity_checks.rs
+++ b/ferveo/benches/benchmarks/validity_checks.rs
@@ -22,7 +22,7 @@ fn gen_keypairs(num: u32) -> Vec<ferveo_common::Keypair<EllipticCurve>> {
 }
 
 pub fn gen_address(i: usize) -> EthereumAddress {
-    EthereumAddress::from_str(&format!("0x{:040}", i)).unwrap()
+    EthereumAddress::from_str(&format!("0x{i:040}")).unwrap()
 }
 
 fn gen_validators(

--- a/ferveo/examples/bench_ark_sizes.rs
+++ b/ferveo/examples/bench_ark_sizes.rs
@@ -47,8 +47,7 @@ pub fn save_data(
     let mut file = OpenOptions::new().append(true).open(&file_path).unwrap();
     writeln!(
         file,
-        "{}|{}|{}|",
-        n_of_elements, type_of_element, serialized_size_in_bytes
+        "{n_of_elements}|{type_of_element}|{serialized_size_in_bytes}|"
     )
     .unwrap();
 }
@@ -66,10 +65,10 @@ fn main() {
         .map(|(n, element)| (n, element))
         .collect::<BTreeSet<_>>();
 
-    println!("Running benchmarks for {:?}", configs);
+    println!("Running benchmarks for {configs:?}");
 
     for (n, element) in configs {
-        println!("number_of_elements: {}, type_of_elements: {}", n, element);
+        println!("number_of_elements: {n}, type_of_elements: {element}");
 
         let g1_affine =
             (0..*n).map(|_| G1Affine::rand(rng)).collect::<Vec<_>>();

--- a/ferveo/examples/bench_primitives_size.rs
+++ b/ferveo/examples/bench_primitives_size.rs
@@ -42,12 +42,8 @@ pub fn save_data(
 
     eprintln!("Appending to file: {}", file_path.display());
     let mut file = OpenOptions::new().append(true).open(&file_path).unwrap();
-    writeln!(
-        file,
-        "{}|{}|{}|",
-        shares_num, threshold, transcript_size_bytes
-    )
-    .unwrap();
+    writeln!(file, "{shares_num}|{threshold}|{transcript_size_bytes}|")
+        .unwrap();
 }
 
 // TODO: Find a way to deduplicate the following methods with benchmarks and test setup
@@ -60,7 +56,7 @@ fn gen_keypairs(num: u32) -> Vec<ferveo_common::Keypair<EllipticCurve>> {
 }
 
 pub fn gen_address(i: usize) -> EthereumAddress {
-    EthereumAddress::from_str(&format!("0x{:040}", i)).unwrap()
+    EthereumAddress::from_str(&format!("0x{i:040}")).unwrap()
 }
 
 fn gen_validators(
@@ -132,10 +128,10 @@ fn main() {
         })
         .collect::<BTreeSet<_>>();
 
-    println!("Running benchmarks for {:?}", configs);
+    println!("Running benchmarks for {configs:?}");
 
     for (shares_num, threshold) in configs {
-        println!("shares_num: {}, threshold: {}", shares_num, threshold);
+        println!("shares_num: {shares_num}, threshold: {threshold}");
         let dkg = setup(*shares_num as u32, threshold, rng);
         let transcript = &dkg.vss.values().next().unwrap();
         let transcript_bytes = bincode::serialize(&transcript).unwrap();

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -394,7 +394,7 @@ pub struct SharedSecret(pub tpke::api::SharedSecret<E>);
 #[cfg(test)]
 mod test_ferveo_api {
     use itertools::izip;
-    use rand::{prelude::StdRng, thread_rng, SeedableRng};
+    use rand::{prelude::StdRng, SeedableRng};
     use tpke::SecretBox;
 
     use crate::{api::*, dkg::test_common::*};
@@ -475,7 +475,6 @@ mod test_ferveo_api {
             // In the meantime, the client creates a ciphertext and decryption request
             let msg = "my-msg".as_bytes().to_vec();
             let aad: &[u8] = "my-aad".as_bytes();
-            let _rng = &mut thread_rng();
             let ciphertext =
                 encrypt(SecretBox::new(msg.clone()), aad, &dkg_public_key)
                     .unwrap();
@@ -570,7 +569,6 @@ mod test_ferveo_api {
             // In the meantime, the client creates a ciphertext and decryption request
             let msg = "my-msg".as_bytes().to_vec();
             let aad: &[u8] = "my-aad".as_bytes();
-            let _rng = &mut thread_rng();
             let ciphertext =
                 encrypt(SecretBox::new(msg.clone()), aad, &public_key).unwrap();
 

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -65,14 +65,12 @@ impl From<FerveoPythonError> for PyErr {
                     expected,
                     actual,
                 ) => InsufficientTranscriptsForAggregate::new_err(format!(
-                    "expected: {}, actual: {}",
-                    expected, actual
+                    "expected: {expected}, actual: {actual}"
                 )),
                 Error::InvalidDkgPublicKey => InvalidDkgPublicKey::new_err(""),
                 Error::InsufficientValidators(expected, actual) => {
                     InsufficientValidators::new_err(format!(
-                        "expected: {}, actual: {}",
-                        expected, actual
+                        "expected: {expected}, actual: {actual}"
                     ))
                 }
                 Error::InvalidTranscriptAggregate => {
@@ -90,8 +88,7 @@ impl From<FerveoPythonError> for PyErr {
                 }
                 Error::InvalidByteLength(expected, actual) => {
                     InvalidByteLength::new_err(format!(
-                        "expected: {}, actual: {}",
-                        expected, actual
+                        "expected: {expected}, actual: {actual}"
                     ))
                 }
                 Error::InvalidVariant(variant) => {

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -30,7 +30,7 @@ pub fn set_panic_hook() {
 }
 
 pub fn map_js_err<T: fmt::Display>(err: T) -> Error {
-    Error::new(&format!("{}", err))
+    Error::new(&format!("{err}"))
 }
 
 pub fn to_js_bytes<T: ToBytes>(t: &T) -> Result<Vec<u8>, Error> {
@@ -577,7 +577,7 @@ pub mod test_common {
     }
 
     pub fn gen_address(i: usize) -> EthereumAddress {
-        EthereumAddress::from_string(&format!("0x{:040}", i)).unwrap()
+        EthereumAddress::from_string(&format!("0x{i:040}")).unwrap()
     }
 
     pub fn gen_validator(i: usize, keypair: &Keypair) -> Validator {

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -229,7 +229,35 @@ generate_boxed_bytes_serialization!(FerveoPublicKey, InnerPublicKey);
 )]
 pub struct Ciphertext(api::Ciphertext);
 
+#[wasm_bindgen]
+impl Ciphertext {
+    #[wasm_bindgen(js_name = "header", getter)]
+    pub fn header(&self) -> JsResult<CiphertextHeader> {
+        let header = self.0.header().map_err(map_js_err)?;
+        Ok(CiphertextHeader(header))
+    }
+
+    #[wasm_bindgen(js_name = "payload", getter)]
+    pub fn payload(&self) -> Vec<u8> {
+        self.0.payload()
+    }
+}
+
 generate_common_methods!(Ciphertext);
+
+#[wasm_bindgen]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    derive_more::From,
+    derive_more::AsRef,
+    derive_more::Into,
+)]
+pub struct CiphertextHeader(api::CiphertextHeader);
+
+generate_common_methods!(CiphertextHeader);
 
 #[wasm_bindgen(js_name = "ferveoEncrypt")]
 pub fn ferveo_encrypt(
@@ -497,7 +525,7 @@ impl AggregatedTranscript {
     pub fn create_decryption_share_precomputed(
         &self,
         dkg: &Dkg,
-        ciphertext: &Ciphertext,
+        ciphertext_header: &CiphertextHeader,
         aad: &[u8],
         validator_keypair: &Keypair,
     ) -> JsResult<DecryptionSharePrecomputed> {
@@ -506,7 +534,7 @@ impl AggregatedTranscript {
             .0
             .create_decryption_share_precomputed(
                 &dkg.0,
-                &ciphertext.0,
+                &ciphertext_header.0,
                 aad,
                 &validator_keypair.0,
             )
@@ -518,7 +546,7 @@ impl AggregatedTranscript {
     pub fn create_decryption_share_simple(
         &self,
         dkg: &Dkg,
-        ciphertext: &Ciphertext,
+        ciphertext_header: &CiphertextHeader,
         aad: &[u8],
         validator_keypair: &Keypair,
     ) -> JsResult<DecryptionShareSimple> {
@@ -527,7 +555,7 @@ impl AggregatedTranscript {
             .0
             .create_decryption_share_simple(
                 &dkg.0,
-                &ciphertext.0,
+                &ciphertext_header.0,
                 aad,
                 &validator_keypair.0,
             )

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -333,7 +333,7 @@ pub(crate) mod test_common {
     }
 
     pub fn gen_address(i: usize) -> EthereumAddress {
-        EthereumAddress::from_str(&format!("0x{:040}", i)).unwrap()
+        EthereumAddress::from_str(&format!("0x{i:040}")).unwrap()
     }
 
     pub fn gen_validators(keypairs: &[Keypair<E>]) -> Vec<Validator<E>> {

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -127,8 +127,8 @@ mod test_dkg_full {
     use ferveo_common::Keypair;
     use group_threshold_cryptography as tpke;
     use group_threshold_cryptography::{
-        Ciphertext, DecryptionSharePrecomputed, DecryptionShareSimple,
-        SecretBox, SharedSecret,
+        DecryptionSharePrecomputed, DecryptionShareSimple, SecretBox,
+        SharedSecret,
     };
     use itertools::izip;
 
@@ -140,7 +140,7 @@ mod test_dkg_full {
     fn make_shared_secret_simple_tdec(
         dkg: &PubliclyVerifiableDkg<E>,
         aad: &[u8],
-        ciphertext: &Ciphertext<E>,
+        ciphertext_header: &tpke::CiphertextHeader<E>,
         validator_keypairs: &[Keypair<E>],
     ) -> (
         PubliclyVerifiableSS<E, Aggregated>,
@@ -159,7 +159,7 @@ mod test_dkg_full {
                         .unwrap();
                     pvss_aggregated
                         .make_decryption_share_simple(
-                            ciphertext,
+                            ciphertext_header,
                             aad,
                             &validator_keypair.decryption_key,
                             validator.share_index,
@@ -211,7 +211,7 @@ mod test_dkg_full {
             let (_, _, shared_secret) = make_shared_secret_simple_tdec(
                 &dkg,
                 aad,
-                &ciphertext,
+                &ciphertext.header().unwrap(),
                 &validator_keypairs,
             );
 
@@ -264,7 +264,7 @@ mod test_dkg_full {
                             .unwrap();
                         pvss_aggregated
                             .make_decryption_share_simple_precomputed(
-                                &ciphertext,
+                                &ciphertext.header().unwrap(),
                                 aad,
                                 &validator_keypair.decryption_key,
                                 validator.share_index,
@@ -307,7 +307,7 @@ mod test_dkg_full {
             make_shared_secret_simple_tdec(
                 &dkg,
                 aad,
-                &ciphertext,
+                &ciphertext.header().unwrap(),
                 &validator_keypairs,
             );
 
@@ -367,7 +367,7 @@ mod test_dkg_full {
         let (_, _, old_shared_secret) = make_shared_secret_simple_tdec(
             &dkg,
             aad,
-            &ciphertext,
+            &ciphertext.header().unwrap(),
             &validator_keypairs,
         );
 
@@ -443,7 +443,7 @@ mod test_dkg_full {
                 .map(|(share_index, validator_keypair)| {
                     pvss_aggregated
                         .make_decryption_share_simple(
-                            &ciphertext,
+                            &ciphertext.header().unwrap(),
                             aad,
                             &validator_keypair.decryption_key,
                             share_index,
@@ -459,7 +459,7 @@ mod test_dkg_full {
             DecryptionShareSimple::create(
                 &new_validator_decryption_key,
                 &new_private_key_share,
-                &ciphertext,
+                &ciphertext.header().unwrap(),
                 aad,
                 &dkg.pvss_params.g_inv(),
             )
@@ -491,7 +491,7 @@ mod test_dkg_full {
         let (_, _, old_shared_secret) = make_shared_secret_simple_tdec(
             &dkg,
             aad,
-            &ciphertext,
+            &ciphertext.header().unwrap(),
             &validator_keypairs,
         );
 
@@ -514,7 +514,7 @@ mod test_dkg_full {
                 .map(|(validator_address, validator_keypair)| {
                     pvss_aggregated
                         .refresh_decryption_share(
-                            &ciphertext,
+                            &ciphertext.header().unwrap(),
                             aad,
                             &validator_keypair.decryption_key,
                             validator_address,

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -14,7 +14,7 @@ use serde_with::serde_as;
 use subproductdomain::fast_multiexp;
 use tpke::{
     prepare_combine_simple, refresh_private_key_share,
-    update_share_for_recovery, Ciphertext, DecryptionSharePrecomputed,
+    update_share_for_recovery, CiphertextHeader, DecryptionSharePrecomputed,
     DecryptionShareSimple, PrivateKeyShare,
 };
 use zeroize::{self, Zeroize, ZeroizeOnDrop};
@@ -329,7 +329,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
 
     pub fn make_decryption_share_simple(
         &self,
-        ciphertext: &Ciphertext<E>,
+        ciphertext: &CiphertextHeader<E>,
         aad: &[u8],
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
@@ -349,7 +349,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
 
     pub fn make_decryption_share_simple_precomputed(
         &self,
-        ciphertext: &Ciphertext<E>,
+        ciphertext_header: &CiphertextHeader<E>,
         aad: &[u8],
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
@@ -366,7 +366,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
             share_index,
             validator_decryption_key,
             &private_key_share,
-            ciphertext,
+            ciphertext_header,
             aad,
             &lagrange_coeffs[share_index],
             g_inv,
@@ -376,7 +376,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
 
     pub fn refresh_decryption_share(
         &self,
-        ciphertext: &Ciphertext<E>,
+        ciphertext_header: &CiphertextHeader<E>,
         aad: &[u8],
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
@@ -396,7 +396,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         DecryptionShareSimple::create(
             validator_decryption_key,
             &refreshed_private_key_share,
-            ciphertext,
+            ciphertext_header,
             aad,
             &dkg.pvss_params.g_inv(),
         )

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "default"
-channel = "1.65.0"
+channel = "1.67.0"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -388,8 +388,7 @@ pub fn bench_ciphertext_validity_checks(c: &mut Criterion) {
             let mut rng = rng.clone();
             let setup = SetupFast::new(shares_num, msg_size, &mut rng);
             move || {
-                black_box(check_ciphertext_validity(
-                    &setup.shared.ciphertext,
+                black_box(setup.shared.ciphertext.check(
                     &setup.shared.aad,
                     &setup.contexts[0].setup_params.g_inv,
                 ))

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -118,7 +118,11 @@ impl SetupSimple {
         // Creating decryption shares
         let decryption_shares: Vec<_> = contexts
             .iter()
-            .map(|context| context.create_share(&ciphertext, aad).unwrap())
+            .map(|context| {
+                context
+                    .create_share(&ciphertext.header().unwrap(), aad)
+                    .unwrap()
+            })
             .collect();
 
         let pub_contexts = contexts[0].clone().public_decryption_contexts;
@@ -190,7 +194,7 @@ pub fn bench_create_decryption_share(c: &mut Criterion) {
                             DecryptionShareSimple::create_unchecked(
                                 &ctx.validator_private_key,
                                 &ctx.private_key_share,
-                                &setup.shared.ciphertext,
+                                &setup.shared.ciphertext.header().unwrap(),
                             )
                         })
                         .collect::<Vec<_>>()
@@ -206,7 +210,7 @@ pub fn bench_create_decryption_share(c: &mut Criterion) {
                         .iter()
                         .map(|context| {
                             context.create_share_precomputed(
-                                &setup.shared.ciphertext,
+                                &setup.shared.ciphertext.header().unwrap(),
                                 &setup.shared.aad,
                             )
                         })
@@ -301,7 +305,7 @@ pub fn bench_share_combine(c: &mut Criterion) {
                 .map(|context| {
                     context
                         .create_share_precomputed(
-                            &setup.shared.ciphertext,
+                            &setup.shared.ciphertext.header().unwrap(),
                             &setup.shared.aad,
                         )
                         .unwrap()

--- a/tpke/src/api.rs
+++ b/tpke/src/api.rs
@@ -3,6 +3,7 @@
 pub type E = ark_bls12_381::Bls12_381;
 pub type G1Prepared = <E as ark_ec::pairing::Pairing>::G1Prepared;
 pub type G1Affine = <E as ark_ec::pairing::Pairing>::G1Affine;
+pub type G2Affine = <E as ark_ec::pairing::Pairing>::G2Affine;
 pub type Fr = ark_bls12_381::Fr;
 pub type PrivateKey = ark_bls12_381::G2Affine;
 pub type Result<T> = crate::Result<T>;
@@ -11,6 +12,8 @@ pub type PrivateDecryptionContextSimple =
 pub type DecryptionSharePrecomputed = crate::DecryptionSharePrecomputed<E>;
 pub type DecryptionShareSimple = crate::DecryptionShareSimple<E>;
 pub type Ciphertext = crate::Ciphertext<E>;
+
+pub type CiphertextHeader = crate::CiphertextHeader<E>;
 pub type TargetField = <E as ark_ec::pairing::Pairing>::TargetField;
 
 pub use crate::{

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -244,7 +244,11 @@ mod tests {
         let plaintext =
             decrypt_symmetric(&ciphertext, aad, &privkey, g_inv).unwrap();
 
-        assert_eq!(msg, plaintext)
+        assert_eq!(msg, plaintext);
+
+        let bad: &[u8] = "bad-aad".as_bytes();
+
+        assert!(decrypt_symmetric(&ciphertext, bad, &privkey, g_inv).is_err());
     }
 
     #[test]

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -32,22 +32,32 @@ pub struct Ciphertext<E: Pairing> {
 }
 
 impl<E: Pairing> Ciphertext<E> {
-    pub fn check(&self, g_inv: &E::G1Prepared) -> Result<bool> {
-        let hash_g2 = E::G2Prepared::from(self.construct_tag_hash()?);
+    pub fn check(&self, aad: &[u8], g_inv: &E::G1Prepared) -> Result<bool> {
+        // Implements a variant of the check in section 4.4.2 of the Ferveo paper:
+        //     'TPKE.CheckCiphertextValidity(U,W,aad)'
+        // See: https://eprint.iacr.org/2022/898.pdf
+        // See: https://nikkolasg.github.io/ferveo/tpke.html#to-validate-ciphertext-for-ind-cca2-security
 
-        Ok(E::multi_pairing(
+        // H_G2(U, sym_ctxt, aad)
+        let hash_g2 = E::G2Prepared::from(construct_tag_hash::<E>(
+            self.commitment,
+            &self.ciphertext[..],
+            aad,
+        )?);
+
+        let is_ciphertext_valid = E::multi_pairing(
+            // e(U, H_G2(U, sym_ctxt, aad)) = e(G, W) ==>
+            // e(U, H_G2(U, sym_ctxt, aad)) * e(G_inv, W) = 1
             [self.commitment.into(), g_inv.to_owned()],
             [hash_g2, self.auth_tag.into()],
         )
-        .0 == E::TargetField::one())
-    }
+        .0 == E::TargetField::one();
 
-    fn construct_tag_hash(&self) -> Result<E::G2Affine> {
-        let mut hash_input = Vec::<u8>::new();
-        self.commitment.serialize_compressed(&mut hash_input)?;
-        hash_input.extend_from_slice(&self.ciphertext);
-
-        hash_to_g2(&hash_input)
+        if is_ciphertext_valid {
+            Ok(true)
+        } else {
+            Err(Error::CiphertextVerificationFailed)
+        }
     }
 
     pub fn serialized_length(&self) -> usize {
@@ -95,42 +105,13 @@ pub fn encrypt<E: Pairing>(
     })
 }
 
-/// Implements the check section 4.4.2 of the Ferveo paper, 'TPKE.CheckCiphertextValidity(U,W,aad)'
-/// See: https://eprint.iacr.org/2022/898.pdf
-/// See: https://nikkolasg.github.io/ferveo/tpke.html#to-validate-ciphertext-for-ind-cca2-security
-pub fn check_ciphertext_validity<E: Pairing>(
-    c: &Ciphertext<E>,
-    aad: &[u8],
-    g_inv: &E::G1Prepared,
-) -> Result<()> {
-    // H_G2(U, aad)
-    let hash_g2 = E::G2Prepared::from(construct_tag_hash::<E>(
-        c.commitment,
-        &c.ciphertext[..],
-        aad,
-    )?);
-
-    let is_ciphertext_valid = E::multi_pairing(
-        // e(U, H_G2(U, aad)) = e(G, W)
-        [c.commitment.into(), g_inv.to_owned()],
-        [hash_g2, c.auth_tag.into()],
-    )
-    .0 == E::TargetField::one();
-
-    if is_ciphertext_valid {
-        Ok(())
-    } else {
-        Err(Error::CiphertextVerificationFailed)
-    }
-}
-
 pub fn decrypt_symmetric<E: Pairing>(
     ciphertext: &Ciphertext<E>,
     aad: &[u8],
     private_key: &E::G2Affine,
     g_inv: &E::G1Prepared,
 ) -> Result<Vec<u8>> {
-    check_ciphertext_validity(ciphertext, aad, g_inv)?;
+    ciphertext.check(aad, g_inv)?;
     let shared_secret = E::pairing(
         E::G1Prepared::from(ciphertext.commitment),
         E::G2Prepared::from(*private_key),
@@ -161,7 +142,7 @@ pub fn decrypt_with_shared_secret<E: Pairing>(
     shared_secret: &SharedSecret<E>,
     g_inv: &E::G1Prepared,
 ) -> Result<Vec<u8>> {
-    check_ciphertext_validity(ciphertext, aad, g_inv)?;
+    ciphertext.check(aad, g_inv)?;
     decrypt_with_shared_secret_unchecked(ciphertext, shared_secret)
 }
 
@@ -267,14 +248,14 @@ mod tests {
             encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
 
         // So far, the ciphertext is valid
-        assert!(check_ciphertext_validity(&ciphertext, aad, &g_inv).is_ok());
+        assert!(ciphertext.check(aad, &g_inv).is_ok());
 
         // Malformed the ciphertext
         ciphertext.ciphertext[0] += 1;
-        assert!(check_ciphertext_validity(&ciphertext, aad, &g_inv).is_err());
+        assert!(ciphertext.check(aad, &g_inv).is_err());
 
         // Malformed the AAD
         let aad = "bad aad".as_bytes();
-        assert!(check_ciphertext_validity(&ciphertext, aad, &g_inv).is_err());
+        assert!(ciphertext.check(aad, &g_inv).is_err());
     }
 }

--- a/tpke/src/ciphertext.rs
+++ b/tpke/src/ciphertext.rs
@@ -2,7 +2,7 @@ use std::ops::Mul;
 
 use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_ff::{One, UniformRand};
-use ark_serialize::{CanonicalSerialize, Compress};
+use ark_serialize::CanonicalSerialize;
 use chacha20poly1305::{
     aead::{generic_array::GenericArray, Aead, KeyInit, Payload},
     ChaCha20Poly1305,
@@ -59,12 +59,6 @@ impl<E: Pairing> Ciphertext<E> {
         } else {
             Err(Error::CiphertextVerificationFailed)
         }
-    }
-
-    pub fn serialized_length(&self) -> usize {
-        self.commitment.serialized_size(Compress::No)
-            + self.auth_tag.serialized_size(Compress::No)
-            + self.ciphertext.len()
     }
 }
 

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -3,9 +3,9 @@ use std::ops::Mul;
 use ark_ec::{pairing::Pairing, CurveGroup};
 
 use crate::{
-    check_ciphertext_validity, prepare_combine_simple, BlindedKeyShare,
-    Ciphertext, DecryptionShareFast, DecryptionSharePrecomputed,
-    DecryptionShareSimple, PrivateKeyShare, PublicKeyShare, Result,
+    prepare_combine_simple, BlindedKeyShare, Ciphertext, DecryptionShareFast,
+    DecryptionSharePrecomputed, DecryptionShareSimple, PrivateKeyShare,
+    PublicKeyShare, Result,
 };
 
 #[derive(Clone, Debug)]
@@ -51,11 +51,7 @@ impl<E: Pairing> PrivateDecryptionContextFast<E> {
         ciphertext: &Ciphertext<E>,
         aad: &[u8],
     ) -> Result<DecryptionShareFast<E>> {
-        check_ciphertext_validity::<E>(
-            ciphertext,
-            aad,
-            &self.setup_params.g_inv,
-        )?;
+        ciphertext.check(aad, &self.setup_params.g_inv)?;
 
         let decryption_share = ciphertext
             .commitment

--- a/tpke/src/context.rs
+++ b/tpke/src/context.rs
@@ -3,9 +3,9 @@ use std::ops::Mul;
 use ark_ec::{pairing::Pairing, CurveGroup};
 
 use crate::{
-    prepare_combine_simple, BlindedKeyShare, Ciphertext, DecryptionShareFast,
-    DecryptionSharePrecomputed, DecryptionShareSimple, PrivateKeyShare,
-    PublicKeyShare, Result,
+    prepare_combine_simple, BlindedKeyShare, Ciphertext, CiphertextHeader,
+    DecryptionShareFast, DecryptionSharePrecomputed, DecryptionShareSimple,
+    PrivateKeyShare, PublicKeyShare, Result,
 };
 
 #[derive(Clone, Debug)]
@@ -78,13 +78,13 @@ pub struct PrivateDecryptionContextSimple<E: Pairing> {
 impl<E: Pairing> PrivateDecryptionContextSimple<E> {
     pub fn create_share(
         &self,
-        ciphertext: &Ciphertext<E>,
+        ciphertext_header: &CiphertextHeader<E>,
         aad: &[u8],
     ) -> Result<DecryptionShareSimple<E>> {
         DecryptionShareSimple::create(
             &self.validator_private_key,
             &self.private_key_share,
-            ciphertext,
+            ciphertext_header,
             aad,
             &self.setup_params.g_inv,
         )
@@ -92,7 +92,7 @@ impl<E: Pairing> PrivateDecryptionContextSimple<E> {
 
     pub fn create_share_precomputed(
         &self,
-        ciphertext: &Ciphertext<E>,
+        ciphertext_header: &CiphertextHeader<E>,
         aad: &[u8],
     ) -> Result<DecryptionSharePrecomputed<E>> {
         let domain = self
@@ -106,7 +106,7 @@ impl<E: Pairing> PrivateDecryptionContextSimple<E> {
             self.index,
             &self.validator_private_key,
             &self.private_key_share,
-            ciphertext,
+            ciphertext_header,
             aad,
             &lagrange_coeffs[self.index],
             &self.setup_params.g_inv,

--- a/tpke/src/decryption.rs
+++ b/tpke/src/decryption.rs
@@ -9,8 +9,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::serde_as;
 
 use crate::{
-    check_ciphertext_validity, generate_random, Ciphertext, PrivateKeyShare,
-    PublicDecryptionContextFast, PublicDecryptionContextSimple, Result,
+    generate_random, Ciphertext, PrivateKeyShare, PublicDecryptionContextFast,
+    PublicDecryptionContextSimple, Result,
 };
 
 #[serde_as]
@@ -94,7 +94,7 @@ impl<E: Pairing> DecryptionShareSimple<E> {
         aad: &[u8],
         g_inv: &E::G1Prepared,
     ) -> Result<Self> {
-        check_ciphertext_validity::<E>(ciphertext, aad, g_inv)?;
+        ciphertext.check(aad, g_inv)?;
         Self::create_unchecked(
             validator_decryption_key,
             private_key_share,
@@ -165,7 +165,7 @@ impl<E: Pairing> DecryptionSharePrecomputed<E> {
         lagrange_coeff: &E::ScalarField,
         g_inv: &E::G1Prepared,
     ) -> Result<Self> {
-        check_ciphertext_validity::<E>(ciphertext, aad, g_inv)?;
+        ciphertext.check(aad, g_inv)?;
         Self::create_unchecked(
             validator_index,
             validator_decryption_key,

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -309,7 +309,9 @@ mod tests {
     ) -> SharedSecret<E> {
         let decryption_shares: Vec<_> = contexts
             .iter()
-            .map(|c| c.create_share(ciphertext, aad).unwrap())
+            .map(|c| {
+                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
+            })
             .collect();
         make_shared_secret(
             &contexts[0].public_decryption_contexts,
@@ -459,7 +461,9 @@ mod tests {
             encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
 
         let bad_aad = "bad aad".as_bytes();
-        assert!(contexts[0].create_share(&ciphertext, bad_aad).is_err());
+        assert!(contexts[0]
+            .create_share(&ciphertext.header().unwrap(), bad_aad)
+            .is_err());
     }
 
     #[test]
@@ -531,7 +535,9 @@ mod tests {
         // We need at least threshold shares to decrypt
         let decryption_shares: Vec<_> = contexts
             .iter()
-            .map(|c| c.create_share(&ciphertext, aad).unwrap())
+            .map(|c| {
+                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
+            })
             .take(threshold)
             .collect();
         let pub_contexts =
@@ -575,7 +581,12 @@ mod tests {
         let decryption_shares: Vec<_> = contexts
             .iter()
             .map(|context| {
-                context.create_share_precomputed(&ciphertext, aad).unwrap()
+                context
+                    .create_share_precomputed(
+                        &ciphertext.header().unwrap(),
+                        aad,
+                    )
+                    .unwrap()
             })
             .collect();
 
@@ -620,7 +631,9 @@ mod tests {
 
         let decryption_shares: Vec<_> = contexts
             .iter()
-            .map(|c| c.create_share(&ciphertext, aad).unwrap())
+            .map(|c| {
+                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
+            })
             .collect();
 
         // In simple tDec variant, we verify decryption shares only after decryption fails.
@@ -772,7 +785,9 @@ mod tests {
         // Get decryption shares from remaining participants
         let mut decryption_shares: Vec<_> = remaining_participants
             .iter()
-            .map(|c| c.create_share(&ciphertext, aad).unwrap())
+            .map(|c| {
+                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
+            })
             .collect();
 
         // Create a decryption share from a recovered private key share
@@ -781,7 +796,7 @@ mod tests {
             DecryptionShareSimple::create(
                 &new_validator_decryption_key,
                 &new_private_key_share,
-                &ciphertext,
+                &ciphertext.header().unwrap(),
                 aad,
                 g_inv,
             )
@@ -845,7 +860,7 @@ mod tests {
                 DecryptionShareSimple::create(
                     &p.validator_private_key,
                     &private_key_share,
-                    &ciphertext,
+                    &ciphertext.header().unwrap(),
                     aad,
                     g_inv,
                 )


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Exposes `Ciphertext.header -> CiphertextHeader` and `Ciphertext.payload -> bytes` from Python bindings

**Issues fixed/closed:**
- #154

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- TODO: Only merge after testing these changes in the downstream
- TODO: Make sure to also update `nucypher-core` stub files, `*.pyi`, upon updating
- Based on https://github.com/nucypher/ferveo/pull/149 - Please review & merge it first
  - There's only one commit to review here: https://github.com/nucypher/ferveo/pull/155/commits/1800d3c5db164947c7cae35433fb8e3ad2650b66
- Who is using `Ciphertext.payload` and how? Decrypter? Can we keep using `Ciphertext` instead?
