### PR TITLE
Refactor of Refresh & Recovery procedures

### DIFF
--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -22,7 +22,7 @@ ark-serialize = "0.4"
 ark-std = "0.4"
 bincode = "1.3"
 ferveo-common = { package = "ferveo-common-pre-release", path = "../ferveo-common", version = "^0.1.1" }
-group-threshold-cryptography = { package = "group-threshold-cryptography-pre-release", path = "../tpke", features = ["api"], version = "^0.2.0" }
+group-threshold-cryptography = { package = "group-threshold-cryptography-pre-release", path = "../tpke", features = ["api", "test-common"], version = "^0.2.0" }
 hex = "0.4.3"
 itertools = "0.10.5"
 measure_time = "0.8"

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -355,7 +355,7 @@ pub(crate) mod test_common {
         my_index: usize,
     ) -> TestSetup {
         let keypairs = gen_keypairs(shares_num);
-        let mut validators = gen_validators(&keypairs);
+        let mut validators = gen_validators(&keypairs.as_slice());
         validators.sort();
         let me = validators[my_index].clone();
         let dkg = PubliclyVerifiableDkg::new(

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -355,7 +355,7 @@ pub(crate) mod test_common {
         my_index: usize,
     ) -> TestSetup {
         let keypairs = gen_keypairs(shares_num);
-        let mut validators = gen_validators(&keypairs.as_slice());
+        let mut validators = gen_validators(keypairs.as_slice());
         validators.sort();
         let me = validators[my_index].clone();
         let dkg = PubliclyVerifiableDkg::new(

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -10,7 +10,7 @@ use serde_with::serde_as;
 
 use crate::{
     aggregate, utils::is_sorted, AggregatedPvss, Error, EthereumAddress,
-    PubliclyVerifiableParams, PubliclyVerifiableSS, Pvss, Result, Validator,
+    PubliclyVerifiableParams, PubliclyVerifiableSS, Result, Validator,
 };
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -156,7 +156,7 @@ impl<E: Pairing> PubliclyVerifiableDkg<E> {
         rng: &mut R,
     ) -> Result<PubliclyVerifiableSS<E>> {
         use ark_std::UniformRand;
-        Pvss::<E>::new(&E::ScalarField::rand(rng), self, rng)
+        PubliclyVerifiableSS::<E>::new(&E::ScalarField::rand(rng), self, rng)
     }
 
     /// Aggregate all received PVSS messages into a single message, prepared to post on-chain
@@ -279,7 +279,7 @@ impl<E: Pairing> PubliclyVerifiableDkg<E> {
     pub fn deal(
         &mut self,
         sender: &Validator<E>,
-        pvss: &Pvss<E>,
+        pvss: &PubliclyVerifiableSS<E>,
     ) -> Result<()> {
         // Add the ephemeral public key and pvss transcript
         let (sender_address, _) = self
@@ -306,11 +306,11 @@ pub struct Aggregation<E: Pairing> {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(bound(
-    serialize = "AggregatedPvss<E>: Serialize, Pvss<E>: Serialize",
-    deserialize = "AggregatedPvss<E>: DeserializeOwned, Pvss<E>: DeserializeOwned"
+    serialize = "AggregatedPvss<E>: Serialize, PubliclyVerifiableSS<E>: Serialize",
+    deserialize = "AggregatedPvss<E>: DeserializeOwned, PubliclyVerifiableSS<E>: DeserializeOwned"
 ))]
 pub enum Message<E: Pairing> {
-    Deal(Pvss<E>),
+    Deal(PubliclyVerifiableSS<E>),
     Aggregate(Aggregation<E>),
 }
 

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -415,8 +415,8 @@ mod test_dkg_full {
         // Now, every participant separately:
         // TODO: Move this logic outside tests (see #162, #163)
         let updated_shares: Vec<_> = remaining_validators
-            .iter()
-            .map(|(_validator_address, validator)| {
+            .values()
+            .map(|validator| {
                 // Current participant receives updates from other participants
                 let updates_for_participant: Vec<_> = share_updates
                     .values()
@@ -496,9 +496,9 @@ mod test_dkg_full {
         assert_eq!(domain_points.len(), security_threshold as usize);
         assert_eq!(decryption_shares.len(), security_threshold as usize);
 
-        let lagrange = tpke::prepare_combine_simple::<E>(&domain_points);
+        let lagrange = tpke::prepare_combine_simple::<E>(domain_points);
         let new_shared_secret =
-            tpke::share_combine_simple::<E>(&decryption_shares, &lagrange);
+            tpke::share_combine_simple::<E>(decryption_shares, &lagrange);
 
         assert_eq!(
             old_shared_secret, new_shared_secret,
@@ -552,8 +552,8 @@ mod test_dkg_full {
         // TODO: Move this logic outside tests (see #162, #163)
         let updated_shares: Vec<_> = dkg
             .validators
-            .iter()
-            .map(|(_validator_address, validator)| {
+            .values()
+            .map(|validator| {
                 // Current participant receives updates from other participants
                 let updates_for_participant: Vec<_> = share_updates
                     .values()
@@ -585,7 +585,7 @@ mod test_dkg_full {
                 .map(|(share_index, validator_keypair)| {
                     DecryptionShareSimple::create(
                         &validator_keypair.decryption_key,
-                        &updated_shares.get(share_index).unwrap(),
+                        updated_shares.get(share_index).unwrap(),
                         &ciphertext.header().unwrap(),
                         aad,
                         &dkg.pvss_params.g_inv(),

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -380,19 +380,20 @@ mod test_dkg_full {
         let removed_validator_addr =
             dkg.validators.keys().last().unwrap().clone();
         let mut remaining_validators = dkg.validators.clone();
-        let removed_validator = remaining_validators.remove(&removed_validator_addr).unwrap();
+        remaining_validators
+            .remove(&removed_validator_addr)
+            .unwrap();
         // dkg.vss.remove(&removed_validator_addr); // TODO: Test whether it makes any difference
 
         // Remember to remove one domain point too
         let mut domain_points = dkg.domain.elements().collect::<Vec<_>>();
-        let old = domain_points.pop().unwrap();
+        domain_points.pop().unwrap();
 
         // Now, we're going to recover a new share at a random point,
         // and check that the shared secret is still the same.
 
         // Our random point:
-        // FIXME: For the moment let's use the old point, but change later to random
-        let x_r = old; // Fr::rand(rng);
+        let x_r = Fr::rand(rng);
 
         // Each participant prepares an update for each other participant
         let share_updates = remaining_validators
@@ -448,12 +449,6 @@ mod test_dkg_full {
             &updated_shares,
         );
 
-        // FIXME: Since for the moment we're using the old point, let's check that this recovers the same share
-        let old_dec_key = validator_keypairs.clone().pop().unwrap().decryption_key;
-        let pvss_aggregated = aggregate(&dkg.vss);
-        let original_private_key_share = pvss_aggregated.decrypt_private_key_share(&old_dec_key, removed_validator.share_index);
-        assert_eq!(new_private_key_share, original_private_key_share, "DIFFERENT SHARE");
-
         // Get decryption shares from remaining participants
         let mut remaining_validator_keypairs = validator_keypairs;
         remaining_validator_keypairs
@@ -505,7 +500,10 @@ mod test_dkg_full {
         let new_shared_secret =
             tpke::share_combine_simple::<E>(&decryption_shares, &lagrange);
 
-        assert_eq!(old_shared_secret, new_shared_secret, "Shared secret reconstruction failed");
+        assert_eq!(
+            old_shared_secret, new_shared_secret,
+            "Shared secret reconstruction failed"
+        );
     }
 
     #[test]

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -413,7 +413,7 @@ mod test_dkg_full {
         // Participants share updates and update their shares
 
         // Now, every participant separately:
-        // TODO: Move this logic outside tests
+        // TODO: Move this logic outside tests (see #162, #163)
         let updated_shares: Vec<_> = remaining_validators
             .iter()
             .map(|(_validator_address, validator)| {
@@ -440,7 +440,7 @@ mod test_dkg_full {
             })
             .collect();
 
-        // TODO: Rename updated_private_shares to something that doesn't imply mutation
+        // TODO: Rename updated_private_shares to something that doesn't imply mutation (see #162, #163)
 
         // Now, we have to combine new share fragments into a new share
         let new_private_key_share = recover_share_from_updated_private_shares(
@@ -549,7 +549,7 @@ mod test_dkg_full {
         // Participants share updates and update their shares
 
         // Now, every participant separately:
-        // TODO: Move this logic outside tests
+        // TODO: Move this logic outside tests (see #162, #163)
         let updated_shares: Vec<_> = dkg
             .validators
             .iter()
@@ -576,8 +576,6 @@ mod test_dkg_full {
                 )
             })
             .collect();
-
-        // TODO: Rename updated_private_shares to something that doesn't imply mutation
 
         // Get decryption shares, now with refreshed private shares:
         let decryption_shares: Vec<DecryptionShareSimple<E>> =

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -17,6 +17,7 @@ pub mod api;
 pub mod dkg;
 pub mod primitives;
 pub mod pvss;
+pub mod refresh;
 pub mod validator;
 
 mod utils;
@@ -24,6 +25,7 @@ mod utils;
 pub use dkg::*;
 pub use primitives::*;
 pub use pvss::*;
+pub use refresh::*;
 pub use validator::*;
 
 #[derive(Debug, thiserror::Error)]
@@ -390,7 +392,7 @@ mod test_dkg_full {
         let share_updates = remaining_validators
             .keys()
             .map(|v_addr| {
-                let deltas_i = tpke::prepare_share_updates_for_recovery::<E>(
+                let deltas_i = prepare_share_updates_for_recovery::<E>(
                     &domain_points,
                     &dkg.pvss_params.h.into_affine(),
                     &x_r,
@@ -428,12 +430,11 @@ mod test_dkg_full {
             .collect();
 
         // Now, we have to combine new share fragments into a new share
-        let new_private_key_share =
-            tpke::recover_share_from_updated_private_shares(
-                &x_r,
-                &domain_points,
-                &updated_shares,
-            );
+        let new_private_key_share = recover_share_from_updated_private_shares(
+            &x_r,
+            &domain_points,
+            &updated_shares,
+        );
 
         // Get decryption shares from remaining participants
         let mut decryption_shares: Vec<DecryptionShareSimple<E>> =
@@ -498,7 +499,7 @@ mod test_dkg_full {
         // Now, we're going to refresh the shares and check that the shared secret is the same
 
         // Dealer computes a new random polynomial with constant term x_r = 0
-        let polynomial = tpke::make_random_polynomial_at::<E>(
+        let polynomial = make_random_polynomial_at::<E>(
             dkg.dkg_params.security_threshold as usize,
             &Fr::zero(),
             rng,

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -519,9 +519,11 @@ mod test_dkg_full {
 
         // Now, we're going to refresh the shares and check that the shared secret is the same
 
-        // Dealer computes a new random polynomial with constant term x_r = 0
+        // Dealer computes a new random polynomial with constant term 0
+        // TODO: Doesn't work if I move this to the loop below
+        let degree = dkg.dkg_params.security_threshold - 1;
         let polynomial = make_random_polynomial_with_root::<E>(
-            dkg.dkg_params.security_threshold as usize,
+            degree as usize,
             &Fr::zero(),
             rng,
         );

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -499,7 +499,7 @@ mod test_dkg_full {
         // Now, we're going to refresh the shares and check that the shared secret is the same
 
         // Dealer computes a new random polynomial with constant term x_r = 0
-        let polynomial = make_random_polynomial_at::<E>(
+        let polynomial = make_random_polynomial_with_root::<E>(
             dkg.dkg_params.security_threshold as usize,
             &Fr::zero(),
             rng,

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -13,15 +13,15 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use subproductdomain::fast_multiexp;
 use tpke::{
-    prepare_combine_simple, refresh_private_key_share,
-    update_share_for_recovery, CiphertextHeader, DecryptionSharePrecomputed,
+    prepare_combine_simple, CiphertextHeader, DecryptionSharePrecomputed,
     DecryptionShareSimple, PrivateKeyShare,
 };
 use zeroize::{self, Zeroize, ZeroizeOnDrop};
 
 use crate::{
-    batch_to_projective_g1, batch_to_projective_g2, utils::is_sorted, Error,
-    PVSSMap, PubliclyVerifiableDkg, Result, Validator,
+    batch_to_projective_g1, batch_to_projective_g2, refresh_private_key_share,
+    update_share_for_recovery, utils::is_sorted, Error, PVSSMap,
+    PubliclyVerifiableDkg, Result, Validator,
 };
 
 /// These are the blinded evaluations of shares of a single random polynomial

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -41,8 +41,8 @@ pub trait Aggregate {}
 /// Apply trait gate to Aggregated marker struct
 impl Aggregate for Aggregated {}
 
-/// Type alias for non aggregated PVSS transcripts
-pub type Pvss<E> = PubliclyVerifiableSS<E>;
+// /// Type alias for non aggregated PVSS transcripts
+// pub type Pvss<E> = PubliclyVerifiableSS<E>;
 
 /// Type alias for aggregated PVSS transcripts
 pub type AggregatedPvss<E> = PubliclyVerifiableSS<E, Aggregated>;
@@ -504,8 +504,8 @@ mod test_pvss {
         let rng = &mut ark_std::test_rng();
         let (dkg, _) = setup_dkg(0);
         let s = ScalarField::rand(rng);
-        let pvss =
-            Pvss::<EllipticCurve>::new(&s, &dkg, rng).expect("Test failed");
+        let pvss = PubliclyVerifiableSS::<EllipticCurve>::new(&s, &dkg, rng)
+            .expect("Test failed");
         // Check that the chosen secret coefficient is correct
         assert_eq!(pvss.coeffs[0], G1::generator().mul(s));
         // Check that a polynomial of the correct degree was created
@@ -548,7 +548,8 @@ mod test_pvss {
         let rng = &mut ark_std::test_rng();
         let (dkg, _) = setup_dkg(0);
         let s = ScalarField::rand(rng);
-        let pvss = Pvss::<EllipticCurve>::new(&s, &dkg, rng).unwrap();
+        let pvss =
+            PubliclyVerifiableSS::<EllipticCurve>::new(&s, &dkg, rng).unwrap();
 
         // So far, everything works
         assert!(pvss.verify_optimistic());

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -19,9 +19,9 @@ use tpke::{
 use zeroize::{self, Zeroize, ZeroizeOnDrop};
 
 use crate::{
-    batch_to_projective_g1, batch_to_projective_g2, refresh_private_key_share,
-    update_share_for_recovery, utils::is_sorted, Error, PVSSMap,
-    PubliclyVerifiableDkg, Result, Validator,
+    apply_updates_to_private_share, batch_to_projective_g1,
+    batch_to_projective_g2, refresh_private_key_share, utils::is_sorted, Error,
+    PVSSMap, PubliclyVerifiableDkg, Result, Validator,
 };
 
 /// These are the blinded evaluations of shares of a single random polynomial
@@ -414,7 +414,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
             .decrypt_private_key_share(validator_decryption_key, share_index);
 
         // And updates their share
-        update_share_for_recovery::<E>(&private_key_share, share_updates)
+        apply_updates_to_private_share::<E>(&private_key_share, share_updates)
     }
 }
 

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -20,8 +20,8 @@ use zeroize::{self, Zeroize, ZeroizeOnDrop};
 
 use crate::{
     apply_updates_to_private_share, batch_to_projective_g1,
-    batch_to_projective_g2, refresh_private_key_share, utils::is_sorted, Error,
-    PVSSMap, PubliclyVerifiableDkg, Result, Validator,
+    batch_to_projective_g2, utils::is_sorted, Error, PVSSMap,
+    PubliclyVerifiableDkg, Result, Validator,
 };
 
 /// These are the blinded evaluations of shares of a single random polynomial
@@ -370,35 +370,6 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
             aad,
             &lagrange_coeffs[share_index],
             g_inv,
-        )
-        .map_err(|e| e.into())
-    }
-
-    pub fn refresh_decryption_share(
-        &self,
-        ciphertext_header: &CiphertextHeader<E>,
-        aad: &[u8],
-        validator_decryption_key: &E::ScalarField,
-        share_index: usize,
-        polynomial: &DensePolynomial<E::ScalarField>,
-        dkg: &PubliclyVerifiableDkg<E>,
-    ) -> Result<DecryptionShareSimple<E>> {
-        let validator_private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
-        let h = dkg.pvss_params.h;
-        let domain_point = dkg.domain.element(share_index);
-        let refreshed_private_key_share = refresh_private_key_share(
-            &h,
-            &domain_point,
-            polynomial,
-            &validator_private_key_share,
-        );
-        DecryptionShareSimple::create(
-            validator_decryption_key,
-            &refreshed_private_key_share,
-            ciphertext_header,
-            aad,
-            &dkg.pvss_params.g_inv(),
         )
         .map_err(|e| e.into())
     }

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -374,6 +374,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         .map_err(|e| e.into())
     }
 
+    // TODO: Consider relocate to different place, maybe PrivateKeyShare? (see #162, #163)
     pub fn update_private_key_share_for_recovery(
         &self,
         validator_decryption_key: &E::ScalarField,

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -116,54 +116,28 @@ pub fn make_random_polynomial_with_root<E: Pairing>(
     poly
 }
 
-// TODO: Expose a method to create a proper decryption share after refreshing
-// TODO: This is just updating a share locally, but not using contributions from others
-pub fn refresh_private_key_share<E: Pairing>(
-    h: &E::G2,
-    domain_point: &E::ScalarField,
-    polynomial: &DensePolynomial<E::ScalarField>,
-    validator_private_key_share: &PrivateKeyShare<E>,
-) -> PrivateKeyShare<E> {
-    let evaluated_polynomial = polynomial.evaluate(domain_point);
-    let share_update = h.mul(evaluated_polynomial);
-    let updated_share =
-        validator_private_key_share.private_key_share.into_group()
-            + share_update;
-    PrivateKeyShare {
-        private_key_share: updated_share.into_affine(),
-    }
-}
-
 #[cfg(test)]
 mod tests_refresh {
 
     use std::collections::HashMap;
 
     use ark_bls12_381::Fr;
-    use ark_ec::{pairing::Pairing, AffineRepr};
-    // use ark_ff::Zero;
+    use ark_ec::pairing::Pairing;
     use ark_std::{test_rng, UniformRand, Zero};
-    // use ferveo_common::{FromBytes, ToBytes};
     use rand_core::RngCore;
 
-    // use tpke::test_common::{make_shared_secret};
-
     type E = ark_bls12_381::Bls12_381;
-    // type TargetField = <E as Pairing>::TargetField;
     type ScalarField = <E as Pairing>::ScalarField;
 
     use crate::{
-        apply_updates_to_private_share, make_random_polynomial_with_root,
-        prepare_share_updates_for_recovery, prepare_share_updates_for_refresh,
-        recover_share_from_updated_private_shares, 
+        apply_updates_to_private_share, prepare_share_updates_for_recovery,
+        prepare_share_updates_for_refresh,
+        recover_share_from_updated_private_shares,
     };
 
     use group_threshold_cryptography::{
-        encrypt,
-        test_common::{make_shared_secret, setup_simple},
-        CiphertextHeader, DecryptionShareSimple,
-        PrivateDecryptionContextSimple, PrivateKeyShare, SecretBox,
-        SharedSecret,
+        test_common::setup_simple, PrivateDecryptionContextSimple,
+        PrivateKeyShare,
     };
 
     fn make_new_share_fragments_for_recovery<R: RngCore>(
@@ -404,6 +378,5 @@ mod tests_refresh {
             shared_private_key,
             new_shared_private_key.private_key_share
         );
-
     }
 }

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -137,10 +137,10 @@ pub fn refresh_private_key_share<E: Pairing>(
 #[cfg(test)]
 mod tests_refresh {
 
-    use std::{collections::HashMap, ops::Mul};
+    use std::collections::HashMap;
 
     use ark_bls12_381::Fr;
-    use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+    use ark_ec::{pairing::Pairing, AffineRepr};
     // use ark_ff::Zero;
     use ark_std::{test_rng, UniformRand, Zero};
     // use ferveo_common::{FromBytes, ToBytes};
@@ -273,11 +273,21 @@ mod tests_refresh {
             .collect::<Vec<_>>();
         let new_private_key_share = recover_share_from_updated_private_shares(
             &x_r,
-            domain_points,
-            &new_share_fragments,
+            &domain_points[..threshold],
+            &new_share_fragments[..threshold],
         );
 
         assert_eq!(new_private_key_share, original_private_key_share);
+
+        // If we don't have enough private share updates, the resulting private share will be incorrect
+        let incorrect_private_key_share =
+            recover_share_from_updated_private_shares(
+                &x_r,
+                &domain_points[..(threshold - 1)],
+                &new_share_fragments[..(threshold - 1)],
+            );
+
+        assert_ne!(incorrect_private_key_share, original_private_key_share);
     }
 
     /// Ñ parties (where t <= Ñ <= N) jointly execute a "share recovery" algorithm, and the output is 1 new share.

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -61,7 +61,7 @@ pub fn recover_share_from_updated_private_shares<E: Pairing>(
     }
 }
 
-pub fn make_random_polynomial_at<E: Pairing>(
+pub fn make_random_polynomial_with_root<E: Pairing>(
     threshold: usize,
     root: &E::ScalarField,
     rng: &mut impl RngCore,
@@ -78,6 +78,7 @@ pub fn make_random_polynomial_at<E: Pairing>(
     let d_i_0 = E::ScalarField::zero() - threshold_poly.evaluate(root);
     threshold_poly[0] = d_i_0;
 
+    // Evaluating the polynomial at the root should result in 0
     debug_assert!(threshold_poly.evaluate(root) == E::ScalarField::zero());
     debug_assert!(threshold_poly.coeffs.len() == threshold);
 
@@ -120,7 +121,7 @@ mod tests_refresh {
     type ScalarField = <E as Pairing>::ScalarField;
 
     use crate::{
-        make_random_polynomial_at, prepare_share_updates_for_recovery,
+        make_random_polynomial_with_root, prepare_share_updates_for_recovery,
         recover_share_from_updated_private_shares, refresh_private_key_share,
         update_share_for_recovery,
     };
@@ -359,7 +360,7 @@ mod tests_refresh {
         // Now, we're going to refresh the shares and check that the shared secret is the same
 
         // Dealer computes a new random polynomial with constant term x_r
-        let polynomial = make_random_polynomial_at::<E>(
+        let polynomial = make_random_polynomial_with_root::<E>(
             threshold,
             &ScalarField::zero(),
             rng,

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -3,10 +3,10 @@ use std::{ops::Mul, usize};
 use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
 use ark_ff::Zero;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
+use group_threshold_cryptography as tpke;
 use itertools::zip_eq;
 use rand_core::RngCore;
-
-use crate::{lagrange_basis_at, PrivateKeyShare};
+use tpke::{lagrange_basis_at, PrivateKeyShare};
 
 /// From PSS paper, section 4.2.1, (https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf)
 pub fn prepare_share_updates_for_recovery<E: Pairing>(

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -100,3 +100,299 @@ pub fn refresh_private_key_share<E: Pairing>(
         private_key_share: updated_share.into_affine(),
     }
 }
+
+#[cfg(test)]
+mod tests_refresh {
+
+    use std::{collections::HashMap, ops::Mul};
+
+    use ark_bls12_381::Fr;
+    use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
+    // use ark_ff::Zero;
+    use ark_std::{test_rng, UniformRand, Zero};
+    // use ferveo_common::{FromBytes, ToBytes};
+    use rand_core::RngCore;
+
+    // use tpke::test_common::{make_shared_secret};
+
+    type E = ark_bls12_381::Bls12_381;
+    // type TargetField = <E as Pairing>::TargetField;
+    type ScalarField = <E as Pairing>::ScalarField;
+
+    use crate::{
+        make_random_polynomial_at, prepare_share_updates_for_recovery,
+        recover_share_from_updated_private_shares, refresh_private_key_share,
+        update_share_for_recovery,
+    };
+
+    use group_threshold_cryptography::{
+        encrypt,
+        test_common::{make_shared_secret, setup_simple},
+        CiphertextHeader, DecryptionShareSimple,
+        PrivateDecryptionContextSimple, PrivateKeyShare, SecretBox,
+        SharedSecret,
+    };
+
+    fn make_new_share_fragments<R: RngCore>(
+        rng: &mut R,
+        threshold: usize,
+        x_r: &Fr,
+        remaining_participants: &[PrivateDecryptionContextSimple<E>],
+    ) -> Vec<PrivateKeyShare<E>> {
+        // Each participant prepares an update for each other participant
+        let domain_points = remaining_participants[0]
+            .public_decryption_contexts
+            .iter()
+            .map(|c| c.domain)
+            .collect::<Vec<_>>();
+        let h = remaining_participants[0].public_decryption_contexts[0].h;
+        let share_updates = remaining_participants
+            .iter()
+            .map(|p| {
+                let deltas_i = prepare_share_updates_for_recovery::<E>(
+                    &domain_points,
+                    &h,
+                    x_r,
+                    threshold,
+                    rng,
+                );
+                (p.index, deltas_i)
+            })
+            .collect::<HashMap<_, _>>();
+
+        // Participants share updates and update their shares
+        let new_share_fragments: Vec<_> = remaining_participants
+            .iter()
+            .map(|p| {
+                // Current participant receives updates from other participants
+                let updates_for_participant: Vec<_> = share_updates
+                    .values()
+                    .map(|updates| *updates.get(p.index).unwrap())
+                    .collect();
+
+                // And updates their share
+                update_share_for_recovery::<E>(
+                    &p.private_key_share,
+                    &updates_for_participant,
+                )
+            })
+            .collect();
+
+        new_share_fragments
+    }
+
+    fn make_shared_secret_from_contexts<E: Pairing>(
+        contexts: &[PrivateDecryptionContextSimple<E>],
+        ciphertext_header: &CiphertextHeader<E>,
+        aad: &[u8],
+    ) -> SharedSecret<E> {
+        let decryption_shares: Vec<_> = contexts
+            .iter()
+            .map(|c| c.create_share(ciphertext_header, aad).unwrap())
+            .collect();
+        make_shared_secret(
+            &contexts[0].public_decryption_contexts,
+            &decryption_shares,
+        )
+    }
+
+    /// Ñ parties (where t <= Ñ <= N) jointly execute a "share recovery" algorithm, and the output is 1 new share.
+    /// The new share is intended to restore a previously existing share, e.g., due to loss or corruption.
+    #[test]
+    fn tdec_simple_variant_share_recovery_at_selected_point() {
+        let rng = &mut test_rng();
+        let shares_num = 16;
+        let threshold = shares_num * 2 / 3;
+
+        let (_, _, mut contexts) =
+            setup_simple::<E>(threshold, shares_num, rng);
+
+        // Prepare participants
+
+        // First, save the soon-to-be-removed participant
+        let selected_participant = contexts.pop().unwrap();
+        let x_r = selected_participant
+            .public_decryption_contexts
+            .last()
+            .unwrap()
+            .domain;
+        let original_private_key_share = selected_participant.private_key_share;
+
+        // Remove one participant from the contexts and all nested structures
+        let mut remaining_participants = contexts;
+        for p in &mut remaining_participants {
+            p.public_decryption_contexts.pop().unwrap();
+        }
+
+        // Each participant prepares an update for each other participant, and uses it to create a new share fragment
+        let new_share_fragments = make_new_share_fragments(
+            rng,
+            threshold,
+            &x_r,
+            &remaining_participants,
+        );
+
+        // Now, we have to combine new share fragments into a new share
+        let domain_points = &remaining_participants[0]
+            .public_decryption_contexts
+            .iter()
+            .map(|ctxt| ctxt.domain)
+            .collect::<Vec<_>>();
+        let new_private_key_share = recover_share_from_updated_private_shares(
+            &x_r,
+            domain_points,
+            &new_share_fragments,
+        );
+
+        assert_eq!(new_private_key_share, original_private_key_share);
+    }
+
+    /// Ñ parties (where t <= Ñ <= N) jointly execute a "share recovery" algorithm, and the output is 1 new share.
+    /// The new share is independent from the previously existing shares. We can use this to on-board a new participant into an existing cohort.
+    #[test]
+    fn tdec_simple_variant_share_recovery_at_random_point() {
+        let rng = &mut test_rng();
+        let shares_num = 16;
+        let threshold = shares_num * 2 / 3;
+        let msg = "my-msg".as_bytes().to_vec();
+        let aad: &[u8] = "my-aad".as_bytes();
+
+        let (pubkey, _, contexts) =
+            setup_simple::<E>(threshold, shares_num, rng);
+        let g_inv = &contexts[0].setup_params.g_inv;
+        let ciphertext =
+            encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
+
+        // Create an initial shared secret
+        let old_shared_secret = make_shared_secret_from_contexts(
+            &contexts,
+            &ciphertext.header().unwrap(),
+            aad,
+        );
+
+        // Now, we're going to recover a new share at a random point and check that the shared secret is still the same
+
+        // Our random point
+        let x_r = ScalarField::rand(rng);
+
+        // Remove one participant from the contexts and all nested structures
+        let mut remaining_participants = contexts.clone();
+        remaining_participants.pop().unwrap();
+        for p in &mut remaining_participants {
+            p.public_decryption_contexts.pop().unwrap();
+        }
+
+        let new_share_fragments = make_new_share_fragments(
+            rng,
+            threshold,
+            &x_r,
+            &remaining_participants,
+        );
+
+        // Now, we have to combine new share fragments into a new share
+        let domain_points = &remaining_participants[0]
+            .public_decryption_contexts
+            .iter()
+            .map(|ctxt| ctxt.domain)
+            .collect::<Vec<_>>();
+        let new_private_key_share = recover_share_from_updated_private_shares(
+            &x_r,
+            domain_points,
+            &new_share_fragments,
+        );
+
+        // Get decryption shares from remaining participants
+        let mut decryption_shares: Vec<_> = remaining_participants
+            .iter()
+            .map(|c| {
+                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
+            })
+            .collect();
+
+        // Create a decryption share from a recovered private key share
+        let new_validator_decryption_key = ScalarField::rand(rng);
+        decryption_shares.push(
+            DecryptionShareSimple::create(
+                &new_validator_decryption_key,
+                &new_private_key_share,
+                &ciphertext.header().unwrap(),
+                aad,
+                g_inv,
+            )
+            .unwrap(),
+        );
+
+        // Creating a shared secret from remaining shares and the recovered one
+        let new_shared_secret = make_shared_secret(
+            &remaining_participants[0].public_decryption_contexts,
+            &decryption_shares,
+        );
+
+        assert_eq!(old_shared_secret, new_shared_secret);
+    }
+
+    /// Ñ parties (where t <= Ñ <= N) jointly execute a "share refresh" algorithm.
+    /// The output is M new shares (with M <= Ñ), with each of the M new shares substituting the
+    /// original share (i.e., the original share is deleted).
+    #[test]
+    fn tdec_simple_variant_share_refreshing() {
+        let rng = &mut test_rng();
+        let shares_num = 16;
+        let threshold = shares_num * 2 / 3;
+        let msg = "my-msg".as_bytes().to_vec();
+        let aad: &[u8] = "my-aad".as_bytes();
+
+        let (pubkey, _, contexts) =
+            setup_simple::<E>(threshold, shares_num, rng);
+        let g_inv = &contexts[0].setup_params.g_inv;
+        let pub_contexts = contexts[0].public_decryption_contexts.clone();
+        let ciphertext =
+            encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
+
+        // Create an initial shared secret
+        let old_shared_secret = make_shared_secret_from_contexts(
+            &contexts,
+            &ciphertext.header().unwrap(),
+            aad,
+        );
+
+        // Now, we're going to refresh the shares and check that the shared secret is the same
+
+        // Dealer computes a new random polynomial with constant term x_r
+        let polynomial = make_random_polynomial_at::<E>(
+            threshold,
+            &ScalarField::zero(),
+            rng,
+        );
+
+        // Dealer shares the polynomial with participants
+
+        // Participants computes new decryption shares
+        let new_decryption_shares: Vec<_> = contexts
+            .iter()
+            .enumerate()
+            .map(|(i, p)| {
+                // Participant computes share updates and update their private key shares
+                let private_key_share = refresh_private_key_share::<E>(
+                    &p.setup_params.h.into_group(),
+                    &p.public_decryption_contexts[i].domain,
+                    &polynomial,
+                    &p.private_key_share,
+                );
+                DecryptionShareSimple::create(
+                    &p.validator_private_key,
+                    &private_key_share,
+                    &ciphertext.header().unwrap(),
+                    aad,
+                    g_inv,
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let new_shared_secret =
+            make_shared_secret(&pub_contexts, &new_decryption_shares);
+
+        assert_eq!(old_shared_secret, new_shared_secret);
+    }
+}

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -130,15 +130,15 @@ mod tests_refresh {
     type E = ark_bls12_381::Bls12_381;
     type ScalarField = <E as Pairing>::ScalarField;
 
+    use group_threshold_cryptography::{
+        test_common::setup_simple, PrivateDecryptionContextSimple,
+        PrivateKeyShare,
+    };
+
     use crate::{
         apply_updates_to_private_share, prepare_share_updates_for_recovery,
         prepare_share_updates_for_refresh,
         recover_share_from_updated_private_shares,
-    };
-
-    use group_threshold_cryptography::{
-        test_common::setup_simple, PrivateDecryptionContextSimple,
-        PrivateKeyShare,
     };
 
     fn make_new_share_fragments_for_recovery<R: RngCore>(
@@ -241,6 +241,7 @@ mod tests_refresh {
         assert_eq!(new_private_key_share, original_private_key_share);
 
         // If we don't have enough private share updates, the resulting private share will be incorrect
+        assert_eq!(domain_points.len(), new_share_fragments.len());
         let incorrect_private_key_share =
             recover_share_from_updated_private_shares(
                 &x_r,
@@ -342,7 +343,7 @@ mod tests_refresh {
             .iter()
             .map(|p| {
                 let deltas_i = prepare_share_updates_for_refresh::<E>(
-                    &domain_points,
+                    domain_points,
                     &h,
                     threshold,
                     rng,

--- a/ferveo/src/refresh.rs
+++ b/ferveo/src/refresh.rs
@@ -22,6 +22,7 @@ pub fn prepare_share_updates_for_recovery<E: Pairing>(
     prepare_share_updates_with_root::<E>(domain_points, h, x_r, threshold, rng)
 }
 
+// TODO: Consider relocating to PrivateKeyShare (see #162, #163)
 /// From PSS paper, section 4.2.3, (https://link.springer.com/content/pdf/10.1007/3-540-44750-4_27.pdf)
 pub fn apply_updates_to_private_share<E: Pairing>(
     private_key_share: &PrivateKeyShare<E>,
@@ -147,6 +148,7 @@ mod tests_refresh {
         remaining_participants: &[PrivateDecryptionContextSimple<E>],
     ) -> Vec<PrivateKeyShare<E>> {
         // Each participant prepares an update for each other participant
+        // TODO: Extract as parameter
         let domain_points = remaining_participants[0]
             .public_decryption_contexts
             .iter()

--- a/tpke/benches/arkworks.rs
+++ b/tpke/benches/arkworks.rs
@@ -10,13 +10,13 @@ use ark_ec::{
     pairing::{prepare_g1, prepare_g2, Pairing},
     AffineRepr, CurveGroup,
 };
-use ark_ff::{BigInteger256, Field, One, UniformRand, Zero};
+use ark_ff::{BigInteger256, Field, UniformRand};
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
 };
 use itertools::izip;
 use rand::prelude::StdRng;
-use rand_core::{RngCore, SeedableRng};
+use rand_core::SeedableRng;
 
 type E = Bls12_381;
 type G1Prepared = <E as Pairing>::G1Prepared;

--- a/tpke/benches/arkworks.rs
+++ b/tpke/benches/arkworks.rs
@@ -249,7 +249,7 @@ pub fn bench_random_poly(c: &mut Criterion) {
             let mut rng = rng.clone();
             move || {
                 black_box(make_random_polynomial_with_root::<E>(
-                    threshold,
+                    threshold - 1,
                     &Fr::zero(),
                     &mut rng,
                 ))
@@ -259,7 +259,7 @@ pub fn bench_random_poly(c: &mut Criterion) {
             let mut rng = rng.clone();
             move || {
                 black_box(naive_make_random_polynomial_with_root::<E>(
-                    threshold,
+                    threshold - 1,
                     &Fr::zero(),
                     &mut rng,
                 ))

--- a/tpke/benches/arkworks.rs
+++ b/tpke/benches/arkworks.rs
@@ -14,7 +14,7 @@ use ark_ff::{BigInteger256, Field, One, UniformRand, Zero};
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
 };
-use group_threshold_cryptography_pre_release::make_random_polynomial_at;
+use group_threshold_cryptography_pre_release::make_random_polynomial_with_root;
 use itertools::izip;
 use rand::prelude::StdRng;
 use rand_core::{RngCore, SeedableRng};
@@ -219,7 +219,7 @@ pub fn bench_random_poly(c: &mut Criterion) {
         result
     }
 
-    pub fn naive_make_random_polynomial_at<E: Pairing>(
+    pub fn naive_make_random_polynomial_with_root<E: Pairing>(
         threshold: usize,
         root: &Fr,
         rng: &mut impl RngCore,
@@ -248,7 +248,7 @@ pub fn bench_random_poly(c: &mut Criterion) {
         let mut ark = {
             let mut rng = rng.clone();
             move || {
-                black_box(make_random_polynomial_at::<E>(
+                black_box(make_random_polynomial_with_root::<E>(
                     threshold,
                     &Fr::zero(),
                     &mut rng,
@@ -258,7 +258,7 @@ pub fn bench_random_poly(c: &mut Criterion) {
         let mut naive = {
             let mut rng = rng.clone();
             move || {
-                black_box(naive_make_random_polynomial_at::<E>(
+                black_box(naive_make_random_polynomial_with_root::<E>(
                     threshold,
                     &Fr::zero(),
                     &mut rng,

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -551,8 +551,11 @@ pub fn bench_refresh_shares(c: &mut Criterion) {
     for &shares_num in NUM_SHARES_CASES.iter() {
         let setup = SetupSimple::new(shares_num, msg_size, rng);
         let threshold = setup.shared.threshold;
-        let polynomial =
-            make_random_polynomial_with_root::<E>(threshold, &Fr::zero(), rng);
+        let polynomial = make_random_polynomial_with_root::<E>(
+            threshold - 1,
+            &Fr::zero(),
+            rng,
+        );
         let p = setup.contexts[0].clone();
         group.bench_function(
             BenchmarkId::new("refresh_private_key_share", shares_num),

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -517,7 +517,7 @@ pub fn bench_recover_share_at_point(c: &mut Criterion) {
                     .collect();
 
                 // And updates their share
-                update_share_for_recovery::<E>(
+                apply_updates_to_private_share::<E>(
                     &p.private_key_share,
                     &updates_for_participant,
                 )

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -552,7 +552,7 @@ pub fn bench_refresh_shares(c: &mut Criterion) {
         let setup = SetupSimple::new(shares_num, msg_size, rng);
         let threshold = setup.shared.threshold;
         let polynomial =
-            make_random_polynomial_at::<E>(threshold, &Fr::zero(), rng);
+            make_random_polynomial_with_root::<E>(threshold, &Fr::zero(), rng);
         let p = setup.contexts[0].clone();
         group.bench_function(
             BenchmarkId::new("refresh_private_key_share", shares_num),

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -470,108 +470,110 @@ pub fn bench_decryption_share_validity_checks(c: &mut Criterion) {
     }
 }
 
-pub fn bench_recover_share_at_point(c: &mut Criterion) {
-    let mut group = c.benchmark_group("RECOVER SHARE");
-    let rng = &mut StdRng::seed_from_u64(0);
-    let msg_size = MSG_SIZE_CASES[0];
+// TODO: Relocate benchmark to ferveo/benches as part of #162, #163
+// pub fn bench_recover_share_at_point(c: &mut Criterion) {
+//     let mut group = c.benchmark_group("RECOVER SHARE");
+//     let rng = &mut StdRng::seed_from_u64(0);
+//     let msg_size = MSG_SIZE_CASES[0];
 
-    for &shares_num in NUM_SHARES_CASES.iter() {
-        let mut setup = SetupSimple::new(shares_num, msg_size, rng);
-        let threshold = setup.shared.threshold;
-        let selected_participant = setup.contexts.pop().unwrap();
-        let x_r = selected_participant
-            .public_decryption_contexts
-            .last()
-            .unwrap()
-            .domain;
-        let mut remaining_participants = setup.contexts;
-        for p in &mut remaining_participants {
-            p.public_decryption_contexts.pop();
-        }
-        let domain_points = &remaining_participants[0]
-            .public_decryption_contexts
-            .iter()
-            .map(|ctxt| ctxt.domain)
-            .collect::<Vec<_>>();
-        let h = remaining_participants[0].public_decryption_contexts[0].h;
-        let share_updates = remaining_participants
-            .iter()
-            .map(|p| {
-                let deltas_i = prepare_share_updates_for_recovery::<E>(
-                    domain_points,
-                    &h,
-                    &x_r,
-                    threshold,
-                    rng,
-                );
-                (p.index, deltas_i)
-            })
-            .collect::<HashMap<_, _>>();
-        let new_share_fragments: Vec<_> = remaining_participants
-            .iter()
-            .map(|p| {
-                // Current participant receives updates from other participants
-                let updates_for_participant: Vec<_> = share_updates
-                    .values()
-                    .map(|updates| *updates.get(p.index).unwrap())
-                    .collect();
+//     for &shares_num in NUM_SHARES_CASES.iter() {
+//         let mut setup = SetupSimple::new(shares_num, msg_size, rng);
+//         let threshold = setup.shared.threshold;
+//         let selected_participant = setup.contexts.pop().unwrap();
+//         let x_r = selected_participant
+//             .public_decryption_contexts
+//             .last()
+//             .unwrap()
+//             .domain;
+//         let mut remaining_participants = setup.contexts;
+//         for p in &mut remaining_participants {
+//             p.public_decryption_contexts.pop();
+//         }
+//         let domain_points = &remaining_participants[0]
+//             .public_decryption_contexts
+//             .iter()
+//             .map(|ctxt| ctxt.domain)
+//             .collect::<Vec<_>>();
+//         let h = remaining_participants[0].public_decryption_contexts[0].h;
+//         let share_updates = remaining_participants
+//             .iter()
+//             .map(|p| {
+//                 let deltas_i = prepare_share_updates_for_recovery::<E>(
+//                     domain_points,
+//                     &h,
+//                     &x_r,
+//                     threshold,
+//                     rng,
+//                 );
+//                 (p.index, deltas_i)
+//             })
+//             .collect::<HashMap<_, _>>();
+//         let new_share_fragments: Vec<_> = remaining_participants
+//             .iter()
+//             .map(|p| {
+//                 // Current participant receives updates from other participants
+//                 let updates_for_participant: Vec<_> = share_updates
+//                     .values()
+//                     .map(|updates| *updates.get(p.index).unwrap())
+//                     .collect();
 
-                // And updates their share
-                apply_updates_to_private_share::<E>(
-                    &p.private_key_share,
-                    &updates_for_participant,
-                )
-            })
-            .collect();
-        group.bench_function(
-            BenchmarkId::new(
-                "recover_share_from_updated_private_shares",
-                shares_num,
-            ),
-            |b| {
-                b.iter(|| {
-                    let _ = black_box(
-                        recover_share_from_updated_private_shares::<E>(
-                            &x_r,
-                            domain_points,
-                            &new_share_fragments,
-                        ),
-                    );
-                });
-            },
-        );
-    }
-}
+//                 // And updates their share
+//                 apply_updates_to_private_share::<E>(
+//                     &p.private_key_share,
+//                     &updates_for_participant,
+//                 )
+//             })
+//             .collect();
+//         group.bench_function(
+//             BenchmarkId::new(
+//                 "recover_share_from_updated_private_shares",
+//                 shares_num,
+//             ),
+//             |b| {
+//                 b.iter(|| {
+//                     let _ = black_box(
+//                         recover_share_from_updated_private_shares::<E>(
+//                             &x_r,
+//                             domain_points,
+//                             &new_share_fragments,
+//                         ),
+//                     );
+//                 });
+//             },
+//         );
+//     }
+// }
 
-pub fn bench_refresh_shares(c: &mut Criterion) {
-    let mut group = c.benchmark_group("REFRESH SHARES");
-    let rng = &mut StdRng::seed_from_u64(0);
-    let msg_size = MSG_SIZE_CASES[0];
+// TODO: Relocate benchmark to ferveo/benches as part of #162, #163
+// pub fn bench_refresh_shares(c: &mut Criterion) {
+//     let mut group = c.benchmark_group("REFRESH SHARES");
+//     let rng = &mut StdRng::seed_from_u64(0);
+//     let msg_size = MSG_SIZE_CASES[0];
 
-    for &shares_num in NUM_SHARES_CASES.iter() {
-        let setup = SetupSimple::new(shares_num, msg_size, rng);
-        let threshold = setup.shared.threshold;
-        let polynomial = make_random_polynomial_with_root::<E>(
-            threshold - 1,
-            &Fr::zero(),
-            rng,
-        );
-        let p = setup.contexts[0].clone();
-        group.bench_function(
-            BenchmarkId::new("refresh_private_key_share", shares_num),
-            |b| {
-                b.iter(|| {
-                    black_box(refresh_private_key_share::<E>(
-                        &p.setup_params.h.into_group(),
-                        &p.public_decryption_contexts[0].domain,
-                        &polynomial,
-                        &p.private_key_share,
-                    ));
-                });
-            },
-        );
-    }
-}
+//     for &shares_num in NUM_SHARES_CASES.iter() {
+//         let setup = SetupSimple::new(shares_num, msg_size, rng);
+//         let threshold = setup.shared.threshold;
+//         let polynomial = make_random_polynomial_with_root::<E>(
+//             threshold - 1,
+//             &Fr::zero(),
+//             rng,
+//         );
+//         let p = setup.contexts[0].clone();
+//         group.bench_function(
+//             BenchmarkId::new("refresh_private_key_share", shares_num),
+//             |b| {
+//                 b.iter(|| {
+//                     black_box(refresh_private_key_share::<E>(
+//                         &p.setup_params.h.into_group(),
+//                         &p.public_decryption_contexts[0].domain,
+//                         &polynomial,
+//                         &p.private_key_share,
+//                     ));
+//                 });
+//             },
+//         );
+//     }
+// }
 
 criterion_group!(
     benches,
@@ -581,8 +583,8 @@ criterion_group!(
     bench_share_encrypt_decrypt,
     bench_ciphertext_validity_checks,
     bench_decryption_share_validity_checks,
-    bench_recover_share_at_point,
-    bench_refresh_shares,
+    // bench_recover_share_at_point,
+    // bench_refresh_shares,
 );
 
 criterion_main!(benches);

--- a/tpke/benches/tpke.rs
+++ b/tpke/benches/tpke.rs
@@ -1,10 +1,7 @@
 #![allow(clippy::redundant_closure)]
 
-use std::collections::HashMap;
-
 use ark_bls12_381::{Bls12_381, Fr, G1Affine as G1, G2Affine as G2};
-use ark_ec::{pairing::Pairing, AffineRepr};
-use ark_ff::Zero;
+use ark_ec::pairing::Pairing;
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
 };

--- a/tpke/src/combine.rs
+++ b/tpke/src/combine.rs
@@ -56,6 +56,8 @@ pub fn prepare_combine_fast<E: Pairing>(
         .collect::<Vec<_>>()
 }
 
+// TODO: Combine `tpke::prepare_combine_simple` and `tpke::share_combine_simple` into
+//  one function and expose it in the tpke::api?
 pub fn prepare_combine_simple<E: Pairing>(
     domain: &[E::ScalarField],
 ) -> Vec<E::ScalarField> {

--- a/tpke/src/decryption.rs
+++ b/tpke/src/decryption.rs
@@ -56,11 +56,13 @@ impl<E: Pairing> ValidatorShareChecksum<E> {
         h: &E::G2,
         ciphertext: &Ciphertext<E>,
     ) -> bool {
+        // See https://github.com/nucypher/ferveo/issues/42#issuecomment-1398953777
         // D_i == e(C_i, Y_i)
         if *decryption_share != E::pairing(self.checksum, *share_aggregate).0 {
             return false;
         }
 
+        // TODO: use multipairing here (h_inv)
         // e(C_i, ek_i) == e(U, H)
         if E::pairing(self.checksum, *validator_public_key)
             != E::pairing(ciphertext.commitment, *h)

--- a/tpke/src/lib.rs
+++ b/tpke/src/lib.rs
@@ -6,7 +6,6 @@ pub mod context;
 pub mod decryption;
 pub mod hash_to_curve;
 pub mod key_share;
-pub mod refresh;
 pub mod secret_box;
 
 // TODO: Only show the public API, tpke::api
@@ -24,7 +23,6 @@ pub use context::*;
 pub use decryption::*;
 pub use hash_to_curve::*;
 pub use key_share::*;
-pub use refresh::*;
 pub use secret_box::*;
 
 #[cfg(feature = "api")]
@@ -276,48 +274,30 @@ pub mod test_common {
         // In precomputed variant, the security threshold is equal to the number of shares
         setup_simple::<E>(shares_num, shares_num, rng)
     }
+
+    pub fn make_shared_secret<E: Pairing>(
+        pub_contexts: &[PublicDecryptionContextSimple<E>],
+        decryption_shares: &[DecryptionShareSimple<E>],
+    ) -> SharedSecret<E> {
+        let domain = pub_contexts.iter().map(|c| c.domain).collect::<Vec<_>>();
+        let lagrange_coeffs = prepare_combine_simple::<E>(&domain);
+        share_combine_simple::<E>(decryption_shares, &lagrange_coeffs)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, ops::Mul};
+    use std::ops::Mul;
 
-    use ark_bls12_381::Fr;
     use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup};
-    use ark_ff::Zero;
     use ark_std::{test_rng, UniformRand};
     use ferveo_common::{FromBytes, ToBytes};
-    use rand_core::RngCore;
 
-    use crate::{
-        refresh::{
-            make_random_polynomial_at, prepare_share_updates_for_recovery,
-            recover_share_from_updated_private_shares,
-            refresh_private_key_share, update_share_for_recovery,
-        },
-        test_common::{setup_simple, *},
-    };
+    use crate::test_common::{make_shared_secret, setup_simple, *};
 
     type E = ark_bls12_381::Bls12_381;
     type TargetField = <E as Pairing>::TargetField;
     type ScalarField = <E as Pairing>::ScalarField;
-
-    fn make_shared_secret_from_contexts<E: Pairing>(
-        contexts: &[PrivateDecryptionContextSimple<E>],
-        ciphertext: &Ciphertext<E>,
-        aad: &[u8],
-    ) -> SharedSecret<E> {
-        let decryption_shares: Vec<_> = contexts
-            .iter()
-            .map(|c| {
-                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
-            })
-            .collect();
-        make_shared_secret(
-            &contexts[0].public_decryption_contexts,
-            &decryption_shares,
-        )
-    }
 
     #[test]
     fn ciphertext_serialization() {
@@ -372,63 +352,6 @@ mod tests {
             g_inv,
         )
         .is_err());
-    }
-
-    fn make_new_share_fragments<R: RngCore>(
-        rng: &mut R,
-        threshold: usize,
-        x_r: &Fr,
-        remaining_participants: &[PrivateDecryptionContextSimple<E>],
-    ) -> Vec<PrivateKeyShare<E>> {
-        // Each participant prepares an update for each other participant
-        let domain_points = remaining_participants[0]
-            .public_decryption_contexts
-            .iter()
-            .map(|c| c.domain)
-            .collect::<Vec<_>>();
-        let h = remaining_participants[0].public_decryption_contexts[0].h;
-        let share_updates = remaining_participants
-            .iter()
-            .map(|p| {
-                let deltas_i = prepare_share_updates_for_recovery::<E>(
-                    &domain_points,
-                    &h,
-                    x_r,
-                    threshold,
-                    rng,
-                );
-                (p.index, deltas_i)
-            })
-            .collect::<HashMap<_, _>>();
-
-        // Participants share updates and update their shares
-        let new_share_fragments: Vec<_> = remaining_participants
-            .iter()
-            .map(|p| {
-                // Current participant receives updates from other participants
-                let updates_for_participant: Vec<_> = share_updates
-                    .values()
-                    .map(|updates| *updates.get(p.index).unwrap())
-                    .collect();
-
-                // And updates their share
-                update_share_for_recovery::<E>(
-                    &p.private_key_share,
-                    &updates_for_participant,
-                )
-            })
-            .collect();
-
-        new_share_fragments
-    }
-
-    fn make_shared_secret<E: Pairing>(
-        pub_contexts: &[PublicDecryptionContextSimple<E>],
-        decryption_shares: &[DecryptionShareSimple<E>],
-    ) -> SharedSecret<E> {
-        let domain = pub_contexts.iter().map(|c| c.domain).collect::<Vec<_>>();
-        let lagrange_coeffs = prepare_combine_simple::<E>(&domain);
-        share_combine_simple::<E>(decryption_shares, &lagrange_coeffs)
     }
 
     #[test]
@@ -678,199 +601,5 @@ mod tests {
             &pub_contexts[0].h.into_group(),
             &ciphertext,
         ));
-    }
-
-    /// Ñ parties (where t <= Ñ <= N) jointly execute a "share recovery" algorithm, and the output is 1 new share.
-    /// The new share is intended to restore a previously existing share, e.g., due to loss or corruption.
-    #[test]
-    fn tdec_simple_variant_share_recovery_at_selected_point() {
-        let rng = &mut test_rng();
-        let shares_num = 16;
-        let threshold = shares_num * 2 / 3;
-
-        let (_, _, mut contexts) =
-            setup_simple::<E>(threshold, shares_num, rng);
-
-        // Prepare participants
-
-        // First, save the soon-to-be-removed participant
-        let selected_participant = contexts.pop().unwrap();
-        let x_r = selected_participant
-            .public_decryption_contexts
-            .last()
-            .unwrap()
-            .domain;
-        let original_private_key_share = selected_participant.private_key_share;
-
-        // Remove one participant from the contexts and all nested structures
-        let mut remaining_participants = contexts;
-        for p in &mut remaining_participants {
-            p.public_decryption_contexts.pop().unwrap();
-        }
-
-        // Each participant prepares an update for each other participant, and uses it to create a new share fragment
-        let new_share_fragments = make_new_share_fragments(
-            rng,
-            threshold,
-            &x_r,
-            &remaining_participants,
-        );
-
-        // Now, we have to combine new share fragments into a new share
-        let domain_points = &remaining_participants[0]
-            .public_decryption_contexts
-            .iter()
-            .map(|ctxt| ctxt.domain)
-            .collect::<Vec<_>>();
-        let new_private_key_share = recover_share_from_updated_private_shares(
-            &x_r,
-            domain_points,
-            &new_share_fragments,
-        );
-
-        assert_eq!(new_private_key_share, original_private_key_share);
-    }
-
-    /// Ñ parties (where t <= Ñ <= N) jointly execute a "share recovery" algorithm, and the output is 1 new share.
-    /// The new share is independent from the previously existing shares. We can use this to on-board a new participant into an existing cohort.
-    #[test]
-    fn tdec_simple_variant_share_recovery_at_random_point() {
-        let rng = &mut test_rng();
-        let shares_num = 16;
-        let threshold = shares_num * 2 / 3;
-        let msg = "my-msg".as_bytes().to_vec();
-        let aad: &[u8] = "my-aad".as_bytes();
-
-        let (pubkey, _, contexts) =
-            setup_simple::<E>(threshold, shares_num, rng);
-        let g_inv = &contexts[0].setup_params.g_inv;
-        let ciphertext =
-            encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
-
-        // Create an initial shared secret
-        let old_shared_secret =
-            make_shared_secret_from_contexts(&contexts, &ciphertext, aad);
-
-        // Now, we're going to recover a new share at a random point and check that the shared secret is still the same
-
-        // Our random point
-        let x_r = ScalarField::rand(rng);
-
-        // Remove one participant from the contexts and all nested structures
-        let mut remaining_participants = contexts.clone();
-        remaining_participants.pop().unwrap();
-        for p in &mut remaining_participants {
-            p.public_decryption_contexts.pop().unwrap();
-        }
-
-        let new_share_fragments = make_new_share_fragments(
-            rng,
-            threshold,
-            &x_r,
-            &remaining_participants,
-        );
-
-        // Now, we have to combine new share fragments into a new share
-        let domain_points = &remaining_participants[0]
-            .public_decryption_contexts
-            .iter()
-            .map(|ctxt| ctxt.domain)
-            .collect::<Vec<_>>();
-        let new_private_key_share = recover_share_from_updated_private_shares(
-            &x_r,
-            domain_points,
-            &new_share_fragments,
-        );
-
-        // Get decryption shares from remaining participants
-        let mut decryption_shares: Vec<_> = remaining_participants
-            .iter()
-            .map(|c| {
-                c.create_share(&ciphertext.header().unwrap(), aad).unwrap()
-            })
-            .collect();
-
-        // Create a decryption share from a recovered private key share
-        let new_validator_decryption_key = ScalarField::rand(rng);
-        decryption_shares.push(
-            DecryptionShareSimple::create(
-                &new_validator_decryption_key,
-                &new_private_key_share,
-                &ciphertext.header().unwrap(),
-                aad,
-                g_inv,
-            )
-            .unwrap(),
-        );
-
-        // Creating a shared secret from remaining shares and the recovered one
-        let new_shared_secret = make_shared_secret(
-            &remaining_participants[0].public_decryption_contexts,
-            &decryption_shares,
-        );
-
-        assert_eq!(old_shared_secret, new_shared_secret);
-    }
-
-    /// Ñ parties (where t <= Ñ <= N) jointly execute a "share refresh" algorithm.
-    /// The output is M new shares (with M <= Ñ), with each of the M new shares substituting the
-    /// original share (i.e., the original share is deleted).
-    #[test]
-    fn tdec_simple_variant_share_refreshing() {
-        let rng = &mut test_rng();
-        let shares_num = 16;
-        let threshold = shares_num * 2 / 3;
-        let msg = "my-msg".as_bytes().to_vec();
-        let aad: &[u8] = "my-aad".as_bytes();
-
-        let (pubkey, _, contexts) =
-            setup_simple::<E>(threshold, shares_num, rng);
-        let g_inv = &contexts[0].setup_params.g_inv;
-        let pub_contexts = contexts[0].public_decryption_contexts.clone();
-        let ciphertext =
-            encrypt::<E>(SecretBox::new(msg), aad, &pubkey, rng).unwrap();
-
-        // Create an initial shared secret
-        let old_shared_secret =
-            make_shared_secret_from_contexts(&contexts, &ciphertext, aad);
-
-        // Now, we're going to refresh the shares and check that the shared secret is the same
-
-        // Dealer computes a new random polynomial with constant term x_r
-        let polynomial = make_random_polynomial_at::<E>(
-            threshold,
-            &ScalarField::zero(),
-            rng,
-        );
-
-        // Dealer shares the polynomial with participants
-
-        // Participants computes new decryption shares
-        let new_decryption_shares: Vec<_> = contexts
-            .iter()
-            .enumerate()
-            .map(|(i, p)| {
-                // Participant computes share updates and update their private key shares
-                let private_key_share = refresh_private_key_share::<E>(
-                    &p.setup_params.h.into_group(),
-                    &p.public_decryption_contexts[i].domain,
-                    &polynomial,
-                    &p.private_key_share,
-                );
-                DecryptionShareSimple::create(
-                    &p.validator_private_key,
-                    &private_key_share,
-                    &ciphertext.header().unwrap(),
-                    aad,
-                    g_inv,
-                )
-                .unwrap()
-            })
-            .collect();
-
-        let new_shared_secret =
-            make_shared_secret(&pub_contexts, &new_decryption_shares);
-
-        assert_eq!(old_shared_secret, new_shared_secret);
     }
 }


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
This PR is mainly a refactor of code related to refresh & recovery procedures. The main contributions are:
* Relocation of refresh & recovery code from the `tpke` crate to the `ferveo` crate
* Fixing incorrect refresh & recovery tests (see e.g., 8ef9e7ff809af400808dbbc750d2afa25a7cde53)
* General improvements in tests

**Issues fixed/closed:**
* Closes #73 

**Why it's needed:**
This work is the basis to implementing the recovery & refresh protocols (see #163)

**Notes for reviewers:**
No breaking changes!

Work in this PR has surfaced these issues:
* #160 
* #161
* #162
* #163

