### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -15,6 +15,8 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
+  WASM_PACK_VERSION: 0.12.0
+  WASM_OPT_VERSION: 0.114.1
 
 jobs:
   check:
@@ -94,7 +96,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.67 # MSRV, `cargo msrv`
+          - 1.71 # MSRV for wasm-opt & wasm-pack
           - stable
         target:
           - wasm32-unknown-unknown
@@ -106,7 +108,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install wasm-pack
+      - run: cargo install wasm-opt@${{ env.WASM_OPT_VERSION }} wasm-pack@${{ env.WASM_PACK_VERSION }}
       - run: wasm-pack test --node
         working-directory: ferveo-wasm
   
@@ -126,7 +128,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install wasm-pack
+      - run: cargo install wasm-opt@${{ env.WASM_OPT_VERSION }} wasm-pack@${{ env.WASM_PACK_VERSION }}
       - run: wasm-pack build --target nodejs
         working-directory: ferveo-wasm
       - uses: borales/actions-yarn@v3.0.0

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -15,8 +15,6 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
-  WASM_PACK_VERSION: 0.12.0
-  WASM_OPT_VERSION: 0.114.1
 
 jobs:
   check:
@@ -96,7 +94,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71 # MSRV for wasm-opt & wasm-pack
+          - 1.67 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown
@@ -108,7 +106,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install wasm-opt@${{ env.WASM_OPT_VERSION }} wasm-pack@${{ env.WASM_PACK_VERSION }}
+      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack test --node
         working-directory: ferveo-wasm
   
@@ -128,7 +126,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
-      - run: cargo install wasm-opt@${{ env.WASM_OPT_VERSION }} wasm-pack@${{ env.WASM_PACK_VERSION }}
+      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack build --target nodejs
         working-directory: ferveo-wasm
       - uses: borales/actions-yarn@v3.0.0

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -477,7 +477,7 @@ pub fn aggregate_for_decryption<E: Pairing>(
         // We're assuming that in every PVSS instance, the shares are in the same order
         .fold(first_share, |acc, shares| {
             acc.into_iter()
-                .zip_eq(shares.into_iter())
+                .zip_eq(shares)
                 .map(|(a, b)| (a + b).into())
                 .collect()
         })


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
- Installs `wasm-pack` from a precompiled binary
- Fixes a listing issue on Rust `stable`

**Why it's needed:**
- Some child dependencies in `wasm-pack` an `wasm-opt` get updated from time to time and that causes MSRV float
- With these changes, we should be able to avoid that in the future, and hence avoid CI breaking from time to time