### PR TITLE
Relax DKG ceremony constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "serde",
  "serde_with",
  "subproductdomain-pre-release",
+ "test-case",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-derive",
@@ -1879,6 +1880,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+ "test-case-core",
 ]
 
 [[package]]

--- a/ferveo-wasm/tests/node.rs
+++ b/ferveo-wasm/tests/node.rs
@@ -8,8 +8,8 @@ use wasm_bindgen_test::*;
 
 type TestSetup = (
     u32,
-    usize,
-    usize,
+    u32,
+    u32,
     Vec<Keypair>,
     Vec<Validator>,
     ValidatorArray,
@@ -21,11 +21,12 @@ type TestSetup = (
 
 fn setup_dkg() -> TestSetup {
     let tau = 1;
-    let shares_num = 16;
+    let shares_num: u32 = 16;
     let security_threshold = shares_num * 2 / 3;
 
-    let validator_keypairs =
-        (0..shares_num).map(gen_keypair).collect::<Vec<Keypair>>();
+    let validator_keypairs = (0..shares_num as usize)
+        .map(gen_keypair)
+        .collect::<Vec<Keypair>>();
     let validators = validator_keypairs
         .iter()
         .enumerate()
@@ -38,8 +39,8 @@ fn setup_dkg() -> TestSetup {
     let messages = validators.iter().map(|sender| {
         let dkg = Dkg::new(
             tau,
-            shares_num as u32,
-            security_threshold as u32,
+            shares_num,
+            security_threshold,
             &validators_js,
             sender,
         )
@@ -54,8 +55,8 @@ fn setup_dkg() -> TestSetup {
 
     let mut dkg = Dkg::new(
         tau,
-        shares_num as u32,
-        security_threshold as u32,
+        shares_num,
+        security_threshold,
         &validators_js,
         &validators[0],
     )
@@ -112,8 +113,8 @@ fn tdec_simple() {
         .map(|(validator, keypair)| {
             let mut dkg = Dkg::new(
                 tau,
-                shares_num as u32,
-                security_threshold as u32,
+                shares_num,
+                security_threshold,
                 &validators_js,
                 &validator,
             )
@@ -166,8 +167,8 @@ fn tdec_precomputed() {
         .map(|(validator, keypair)| {
             let mut dkg = Dkg::new(
                 tau,
-                shares_num as u32,
-                security_threshold as u32,
+                shares_num,
+                security_threshold,
                 &validators_js,
                 &validator,
             )

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -51,6 +51,7 @@ wasm-bindgen-derive = { version = "0.2.1", optional = true }
 criterion = "0.3" # supports pprof, # TODO: Figure out if/how we can update to 0.4
 digest = { version = "0.10.0", features = ["alloc"] }
 pprof = { version = "0.6", features = ["flamegraph", "criterion"] }
+test-case = "3.3.1"
 
 # WASM bindings
 console_error_panic_hook = "0.1.7"

--- a/ferveo/benches/benchmarks/validity_checks.rs
+++ b/ferveo/benches/benchmarks/validity_checks.rs
@@ -45,11 +45,7 @@ fn setup_dkg(
     let me = validators[validator].clone();
     PubliclyVerifiableDkg::new(
         &validators,
-        &DkgParams {
-            tau: 0,
-            security_threshold: shares_num / 3,
-            shares_num,
-        },
+        &DkgParams::new(0, shares_num / 3, shares_num).unwrap(),
         &me,
     )
     .expect("Setup failed")

--- a/ferveo/examples/bench_primitives_size.rs
+++ b/ferveo/examples/bench_primitives_size.rs
@@ -80,11 +80,7 @@ fn setup_dkg(
     let me = validators[validator].clone();
     PubliclyVerifiableDkg::new(
         &validators,
-        &DkgParams {
-            tau: 0,
-            security_threshold,
-            shares_num,
-        },
+        &DkgParams::new(0, security_threshold, shares_num).unwrap(),
         &me,
     )
     .expect("Setup failed")

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -93,7 +93,17 @@ impl From<FerveoPythonError> for PyErr {
                 }
                 Error::InvalidVariant(variant) => {
                     InvalidVariant::new_err(variant.to_string())
-                }
+                },
+                Error::InvalidDkgParameters(num_shares, security_threshold) => {
+                    InvalidDkgParameters::new_err(format!(
+                        "num_shares: {num_shares}, security_threshold: {security_threshold}"
+                    ))
+                },
+                Error::InvalidShareIndex(index) => {
+                    InvalidShareIndex::new_err(format!(
+                        "{index}"
+                    ))
+                },
             },
             _ => default(),
         }
@@ -128,6 +138,8 @@ create_exception!(exceptions, ValidatorPublicKeyMismatch, PyValueError);
 create_exception!(exceptions, SerializationError, PyValueError);
 create_exception!(exceptions, InvalidByteLength, PyValueError);
 create_exception!(exceptions, InvalidVariant, PyValueError);
+create_exception!(exceptions, InvalidDkgParameters, PyValueError);
+create_exception!(exceptions, InvalidShareIndex, PyValueError);
 
 fn from_py_bytes<T: FromBytes>(bytes: &[u8]) -> PyResult<T> {
     T::from_bytes(bytes)

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -510,15 +510,13 @@ impl AggregatedTranscript {
     #[wasm_bindgen]
     pub fn verify(
         &self,
-        shares_num: usize,
+        shares_num: u32,
         messages: &ValidatorMessageArray,
     ) -> JsResult<bool> {
         set_panic_hook();
         let messages = unwrap_messages_js(messages)?;
-        let is_valid = self
-            .0
-            .verify(shares_num as u32, &messages)
-            .map_err(map_js_err)?;
+        let is_valid =
+            self.0.verify(shares_num, &messages).map_err(map_js_err)?;
         Ok(is_valid)
     }
 

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -19,12 +19,15 @@ use zeroize::{self, Zeroize, ZeroizeOnDrop};
 
 use crate::{
     apply_updates_to_private_share, batch_to_projective_g1,
-    batch_to_projective_g2, utils::is_sorted, Error, PVSSMap,
-    PubliclyVerifiableDkg, Result, Validator,
+    batch_to_projective_g2, Error, PVSSMap, PubliclyVerifiableDkg, Result,
+    ValidatorsMap,
 };
 
 /// These are the blinded evaluations of shares of a single random polynomial
-pub type ShareEncryptions<E> = <E as Pairing>::G2Affine;
+pub type ShareEncryption<E> = <E as Pairing>::G2Affine;
+
+pub type ShareEncryptionMap<E> =
+    std::collections::BTreeMap<usize, ShareEncryption<E>>;
 
 /// Marker struct for unaggregated PVSS transcripts
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -115,7 +118,7 @@ pub struct PubliclyVerifiableSS<E: Pairing, T = Unaggregated> {
     /// The shares to be dealt to each validator
     #[serde_as(as = "ferveo_common::serialization::SerdeAs")]
     // pub shares: Vec<ShareEncryptions<E>>, // TODO: Using a custom type instead of referring to E:G2Affine breaks the serialization
-    pub shares: Vec<E::G2Affine>,
+    pub shares: ShareEncryptionMap<E>,
 
     /// Proof of Knowledge
     #[serde_as(as = "ferveo_common::serialization::SerdeAs")]
@@ -138,7 +141,7 @@ impl<E: Pairing, T> PubliclyVerifiableSS<E, T> {
     ) -> Result<Self> {
         let phi = SecretPolynomial::<E>::new(
             s,
-            (dkg.dkg_params.security_threshold - 1) as usize,
+            (dkg.dkg_params.security_threshold() - 1) as usize,
             rng,
         );
 
@@ -151,17 +154,23 @@ impl<E: Pairing, T> PubliclyVerifiableSS<E, T> {
             .values()
             .map(|validator| {
                 // ek_{i}^{eval_i}, i = validator index
-                fast_multiexp(
+                let share_encryption = fast_multiexp(
                     // &evals.evals[i..i] = &evals.evals[i]
                     &[evals.evals[validator.share_index]], // one share per validator
                     validator.validator.public_key.encryption_key.into_group(),
-                )[0]
+                )[0];
+                println!(
+                    "share_index: {}, share_encryption: {}",
+                    validator.share_index, share_encryption
+                );
+                (validator.share_index, share_encryption)
             })
-            .collect::<Vec<ShareEncryptions<E>>>();
-        if shares.len() != dkg.validators.len() {
+            .collect::<ShareEncryptionMap<E>>();
+
+        if shares.len() < dkg.dkg_params.shares_num() as usize {
             return Err(Error::InsufficientValidators(
                 shares.len() as u32,
-                dkg.validators.len() as u32,
+                dkg.dkg_params.shares_num(),
             ));
         }
 
@@ -201,17 +210,11 @@ impl<E: Pairing, T> PubliclyVerifiableSS<E, T> {
     /// transcript was at fault so that the can issue a new one. This
     /// function may also be used for that purpose.
     pub fn verify_full(&self, dkg: &PubliclyVerifiableDkg<E>) -> bool {
-        let validators = dkg
-            .validators
-            .values()
-            .map(|v| v.validator.clone())
-            .collect::<Vec<_>>();
-        let validators = validators.as_slice();
         do_verify_full(
             &self.coeffs,
             &self.shares,
             &dkg.pvss_params,
-            validators,
+            &dkg.validators,
             &dkg.domain,
         )
     }
@@ -220,58 +223,67 @@ impl<E: Pairing, T> PubliclyVerifiableSS<E, T> {
 // TODO: Return validator that failed the check
 pub fn do_verify_full<E: Pairing>(
     pvss_coefficients: &[E::G1Affine],
-    pvss_encrypted_shares: &[E::G2Affine],
+    pvss_share_map: &ShareEncryptionMap<E>,
     pvss_params: &PubliclyVerifiableParams<E>,
-    validators: &[Validator<E>],
+    validator_map: &ValidatorsMap<E>,
     domain: &ark_poly::GeneralEvaluationDomain<E::ScalarField>,
 ) -> bool {
     let mut commitment = batch_to_projective_g1::<E>(pvss_coefficients);
     domain.fft_in_place(&mut commitment);
 
-    // At this point, validators must be sorted
-    assert!(is_sorted(validators));
+    for validator in validator_map.values() {
+        println!("validator.share_index: {}", validator.share_index);
+    }
+
+    println!("pvss_encrypted_shares.len(): {}", pvss_share_map.len());
+    println!("validator_map.len(): {}", validator_map.len());
 
     // Each validator checks that their share is correct
-    validators
-        .iter()
-        .zip(pvss_encrypted_shares.iter())
-        .enumerate()
-        .all(|(share_index, (validator, y_i))| {
-            // TODO: Check #3 is missing
-            // See #3 in 4.2.3 section of https://eprint.iacr.org/2022/898.pdf
+    validator_map.values().all(|validator| {
+        // TODO: Check #3 is missing
+        // See #3 in 4.2.3 section of https://eprint.iacr.org/2022/898.pdf
 
-            // Validator checks aggregated shares against commitment
-            let ek_i = validator.public_key.encryption_key.into_group();
-            let a_i = &commitment[share_index];
-            // We verify that e(G, Y_i) = e(A_i, ek_i) for validator i
-            // See #4 in 4.2.3 section of https://eprint.iacr.org/2022/898.pdf
-            // e(G,Y) = e(A, ek)
-            E::pairing(pvss_params.g, *y_i) == E::pairing(a_i, ek_i)
-        })
+        // Validator checks aggregated shares against commitment
+        let ek_i = validator.validator.public_key.encryption_key.into_group();
+        let a_i = &commitment[validator.share_index];
+        let y_i = &pvss_share_map[&validator.share_index];
+        println!("share index: {}", validator.share_index);
+        println!("ek_i: {ek_i}");
+        println!("a_i: {a_i}");
+        println!("y_i: {y_i}");
+
+        // We verify that e(G, Y_i) = e(A_i, ek_i) for validator i
+        // See #4 in 4.2.3 section of https://eprint.iacr.org/2022/898.pdf
+        // e(G,Y) = e(A, ek)
+        let result = E::pairing(pvss_params.g, *y_i) == E::pairing(a_i, ek_i);
+        println!("result: {result}");
+        result
+    })
 }
 
 pub fn do_verify_aggregation<E: Pairing>(
     pvss_agg_coefficients: &[E::G1Affine],
-    pvss_agg_encrypted_shares: &[E::G2Affine],
+    share_encryption_map: &ShareEncryptionMap<E>,
     pvss_params: &PubliclyVerifiableParams<E>,
-    validators: &[Validator<E>],
+    validator_map: &ValidatorsMap<E>,
     domain: &ark_poly::GeneralEvaluationDomain<E::ScalarField>,
-    vss: &PVSSMap<E>,
+    pvss_map: &PVSSMap<E>,
 ) -> Result<bool> {
     let is_valid = do_verify_full(
         pvss_agg_coefficients,
-        pvss_agg_encrypted_shares,
+        share_encryption_map,
         pvss_params,
-        validators,
+        validator_map,
         domain,
     );
     if !is_valid {
+        // TODO: Throws here
         return Err(Error::InvalidTranscriptAggregate);
     }
 
     // Now, we verify that the aggregated PVSS transcript is a valid aggregation
     let mut y = E::G1::zero();
-    for (_, pvss) in vss.iter() {
+    for (_, pvss) in pvss_map.iter() {
         y += pvss.coeffs[0].into_group();
     }
     if y.into_affine() == pvss_agg_coefficients[0] {
@@ -291,17 +303,11 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         &self,
         dkg: &PubliclyVerifiableDkg<E>,
     ) -> Result<bool> {
-        let validators = dkg
-            .validators
-            .values()
-            .map(|v| v.validator.clone())
-            .collect::<Vec<_>>();
-        let validators = validators.as_slice();
         do_verify_aggregation(
             &self.coeffs,
             &self.shares,
             &dkg.pvss_params,
-            validators,
+            &dkg.validators,
             &dkg.domain,
             &dkg.vss,
         )
@@ -311,19 +317,19 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         &self,
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
-    ) -> PrivateKeyShare<E> {
+    ) -> Result<PrivateKeyShare<E>> {
         // Decrypt private key shares https://nikkolasg.github.io/ferveo/pvss.html#validator-decryption-of-private-key-shares
         let private_key_share = self
             .shares
-            .get(share_index)
-            .unwrap()
+            .get(&share_index)
+            .ok_or(Error::InvalidShareIndex(share_index as u32))?
             .mul(
                 validator_decryption_key
                     .inverse()
                     .expect("Validator decryption key must have an inverse"),
             )
             .into_affine();
-        PrivateKeyShare { private_key_share }
+        Ok(PrivateKeyShare { private_key_share })
     }
 
     pub fn make_decryption_share_simple(
@@ -335,7 +341,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         g_inv: &E::G1Prepared,
     ) -> Result<DecryptionShareSimple<E>> {
         let private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
+            .decrypt_private_key_share(validator_decryption_key, share_index)?;
         DecryptionShareSimple::create(
             validator_decryption_key,
             &private_key_share,
@@ -356,7 +362,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         g_inv: &E::G1Prepared,
     ) -> Result<DecryptionSharePrecomputed<E>> {
         let private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
+            .decrypt_private_key_share(validator_decryption_key, share_index)?;
 
         // We use the `prepare_combine_simple` function to precompute the lagrange coefficients
         let lagrange_coeffs = prepare_combine_simple::<E>(domain_points);
@@ -379,13 +385,16 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
         share_updates: &[E::G2],
-    ) -> PrivateKeyShare<E> {
+    ) -> Result<PrivateKeyShare<E>> {
         // Retrieves their private key share
         let private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
+            .decrypt_private_key_share(validator_decryption_key, share_index)?;
 
         // And updates their share
-        apply_updates_to_private_share::<E>(&private_key_share, share_updates)
+        Ok(apply_updates_to_private_share::<E>(
+            &private_key_share,
+            share_updates,
+        ))
     }
 }
 
@@ -402,7 +411,13 @@ pub fn aggregate<E: Pairing>(
     let mut coeffs = batch_to_projective_g1::<E>(&first_pvss.coeffs);
     let mut sigma = first_pvss.sigma;
 
-    let mut shares = batch_to_projective_g2::<E>(&first_pvss.shares);
+    // Ordering of shares doesn't matter here, so we can just collect them from the map
+    let shares = first_pvss
+        .shares
+        .values()
+        .cloned()
+        .collect::<Vec<ShareEncryption<E>>>();
+    let mut shares = batch_to_projective_g2::<E>(&shares);
 
     // So now we're iterating over the PVSS instances, and adding their coefficients and shares, and their sigma
     // sigma is the sum of all the sigma_i, which is the proof of knowledge of the secret polynomial
@@ -416,9 +431,16 @@ pub fn aggregate<E: Pairing>(
         shares
             .iter_mut()
             .zip_eq(next.shares.iter())
-            .for_each(|(a, b)| *a += b);
+            .for_each(|(a, (_, b))| *a += b);
     }
     let shares = E::G2::normalize_batch(&shares);
+    // TODO: There is just one share, but we need to convert it back to a map
+    // TODO: Find a better way to do this
+    let shares = shares
+        .into_iter()
+        .enumerate()
+        .map(|(i, share)| (i, share))
+        .collect::<ShareEncryptionMap<E>>();
 
     PubliclyVerifiableSS {
         coeffs: E::G1::normalize_batch(&coeffs),
@@ -430,18 +452,30 @@ pub fn aggregate<E: Pairing>(
 
 pub fn aggregate_for_decryption<E: Pairing>(
     dkg: &PubliclyVerifiableDkg<E>,
-) -> Vec<ShareEncryptions<E>> {
+) -> Vec<ShareEncryption<E>> {
     // From docs: https://nikkolasg.github.io/ferveo/pvss.html?highlight=aggregate#aggregation
     // "Two PVSS instances may be aggregated into a single PVSS instance by adding elementwise each of the corresponding group elements."
-    let shares = dkg
+    let share_maps = dkg
         .vss
         .values()
         .map(|pvss| pvss.shares.clone())
-        .collect::<Vec<_>>();
-    let first_share = shares
-        .first()
-        .expect("Need one or more decryption shares to aggregate")
-        .to_vec();
+        .collect::<Vec<ShareEncryptionMap<E>>>();
+
+    // Now, get shares from each map. Sort them by index, and then collect them into a vector
+    let shares = share_maps
+        .into_iter()
+        .map(|share_map| {
+            share_map
+                .into_iter()
+                .sorted_by_key(|(index, _)| *index)
+                .map(|(_, share)| share)
+                .collect::<Vec<ShareEncryption<E>>>()
+        })
+        .collect::<Vec<Vec<ShareEncryption<E>>>>();
+
+    // Now, we're going to add the shares together
+    let first_share = shares[0].clone();
+
     shares
         .into_iter()
         .skip(1)
@@ -456,10 +490,11 @@ pub fn aggregate_for_decryption<E: Pairing>(
 
 #[cfg(test)]
 mod test_pvss {
-    use ark_bls12_381::Bls12_381 as EllipticCurve;
+    use ark_bls12_381::{Bls12_381 as EllipticCurve, Bls12_381};
     use ark_ec::AffineRepr;
     use ark_ff::UniformRand;
     use rand::seq::SliceRandom;
+    use test_case::test_case;
 
     use super::*;
     use crate::{dkg::test_common::*, utils::is_sorted};
@@ -468,12 +503,35 @@ mod test_pvss {
     type G1 = <EllipticCurve as Pairing>::G1Affine;
     type G2 = <EllipticCurve as Pairing>::G2Affine;
 
+    fn _setup_dkg(
+        shares_num: u32,
+        validators_num: u32,
+    ) -> PubliclyVerifiableDkg<Bls12_381> {
+        let (dkg, _) = setup_dkg_for_me_with_n_validators(
+            2,
+            shares_num,
+            0,
+            validators_num,
+        );
+        dkg
+    }
+
+    fn _setup_dealt_dkg(
+        shares_num: u32,
+        validators_num: u32,
+    ) -> PubliclyVerifiableDkg<Bls12_381> {
+        let (dkg, _) =
+            setup_dealt_dkg_with_n_validators(2, shares_num, validators_num);
+        dkg
+    }
+
     /// Test the happy flow that a pvss with the correct form is created
     /// and that appropriate validations pass
-    #[test]
-    fn test_new_pvss() {
+    #[test_case(4, 4; "number of shares is equal to number of validators")]
+    #[test_case(4, 6; "number of shares is smaller than the number of validators")]
+    fn test_new_pvss(shares_num: u32, validators_num: u32) {
         let rng = &mut ark_std::test_rng();
-        let (dkg, _) = setup_dkg(0);
+        let dkg = _setup_dkg(shares_num, validators_num);
         let s = ScalarField::rand(rng);
         let pvss = PubliclyVerifiableSS::<EllipticCurve>::new(&s, &dkg, rng)
             .expect("Test failed");
@@ -482,7 +540,7 @@ mod test_pvss {
         // Check that a polynomial of the correct degree was created
         assert_eq!(
             pvss.coeffs.len(),
-            dkg.dkg_params.security_threshold as usize
+            dkg.dkg_params.security_threshold() as usize
         );
         // Check that the correct number of shares were created
         assert_eq!(pvss.shares.len(), dkg.validators.len());
@@ -496,10 +554,15 @@ mod test_pvss {
 
     /// Check that if the proof of knowledge is wrong,
     /// the optimistic verification of PVSS fails
-    #[test]
-    fn test_verify_pvss_wrong_proof_of_knowledge() {
+    #[test_case(4, 4; "number of shares is equal to number of validators")]
+    #[test_case(4, 6; "number of shares is smaller than the number of validators")]
+    fn test_verify_pvss_wrong_proof_of_knowledge(
+        shares_num: u32,
+        validators_num: u32,
+    ) {
         let rng = &mut ark_std::test_rng();
-        let (dkg, _) = setup_dkg(0);
+        // Make sure it works for relaxed DKG ceremony constraints
+        let dkg = _setup_dkg(shares_num, validators_num);
         let mut s = ScalarField::rand(rng);
         // Ensure that the proof of knowledge is not zero
         while s == ScalarField::zero() {
@@ -514,13 +577,20 @@ mod test_pvss {
     }
 
     /// Check that if PVSS shares are tampered with, the full verification fails
-    #[test]
-    fn test_verify_pvss_bad_shares() {
+    #[test_case(4, 4; "number of shares is equal to number of validators")]
+    #[test_case(4, 6; "number of shares is smaller than the number of validators")]
+    fn test_verify_pvss_bad_shares(shares_num: u32, validators_num: u32) {
         let rng = &mut ark_std::test_rng();
-        let (dkg, _) = setup_dkg(0);
-        let s = ScalarField::rand(rng);
+        let keypairs = gen_keypairs(validators_num);
+        let mut validators = gen_validators(&keypairs);
+        validators.sort();
+        let _me = validators[0].clone();
+
+        let dkg = _setup_dkg(shares_num, validators_num);
+        let secret = ScalarField::rand(rng);
         let pvss =
-            PubliclyVerifiableSS::<EllipticCurve>::new(&s, &dkg, rng).unwrap();
+            PubliclyVerifiableSS::<EllipticCurve>::new(&secret, &dkg, rng)
+                .unwrap();
 
         // So far, everything works
         assert!(pvss.verify_optimistic());
@@ -528,7 +598,7 @@ mod test_pvss {
 
         // Now, we're going to tamper with the PVSS shares
         let mut bad_pvss = pvss;
-        bad_pvss.shares[0] = G2::zero();
+        bad_pvss.shares.insert(0_usize, G2::zero());
 
         // Optimistic verification should not catch this issue
         assert!(bad_pvss.verify_optimistic());
@@ -543,7 +613,6 @@ mod test_pvss {
         let rng = &mut ark_std::test_rng();
 
         let shares_num = 4;
-        let security_threshold = shares_num - 1;
         let keypairs = gen_keypairs(shares_num);
         let mut validators = gen_validators(&keypairs);
         let me = validators[0].clone();
@@ -555,11 +624,7 @@ mod test_pvss {
         // And because of that the DKG should fail
         let result = PubliclyVerifiableDkg::new(
             &validators,
-            &DkgParams {
-                tau: 0,
-                security_threshold,
-                shares_num,
-            },
+            &DkgParams::new(0, 2, shares_num).unwrap(),
             &me,
         );
         assert!(result.is_err());
@@ -571,14 +636,15 @@ mod test_pvss {
 
     /// Check that happy flow of aggregating PVSS transcripts
     /// Should have the correct form and validations pass
-    #[test]
-    fn test_aggregate_pvss() {
-        let (dkg, _) = setup_dealt_dkg();
+    #[test_case(4, 4; "number of shares is equal to number of validators")]
+    #[test_case(4, 6; "number of shares is smaller than the number of validators")]
+    fn test_aggregate_pvss(shares_num: u32, validators_num: u32) {
+        let dkg = _setup_dealt_dkg(shares_num, validators_num);
         let aggregate = aggregate(&dkg.vss);
         // Check that a polynomial of the correct degree was created
         assert_eq!(
             aggregate.coeffs.len(),
-            dkg.dkg_params.security_threshold as usize
+            dkg.dkg_params.security_threshold() as usize
         );
         // Check that the correct number of shares were created
         assert_eq!(aggregate.shares.len(), dkg.validators.len());
@@ -592,12 +658,16 @@ mod test_pvss {
 
     /// Check that if the aggregated pvss transcript has an
     /// incorrect constant term, the verification fails
-    #[test]
-    fn test_verify_aggregation_fails_if_constant_term_wrong() {
-        let (dkg, _) = setup_dealt_dkg();
+    #[test_case(4, 4; "number of shares is equal to number of validators")]
+    #[test_case(4, 6; "number of shares is smaller than the number of validators")]
+    fn test_verify_aggregation_fails_if_constant_term_wrong(
+        shares_num: u32,
+        validators_num: u32,
+    ) {
+        let dkg = _setup_dealt_dkg(shares_num, validators_num);
         let mut aggregated = aggregate(&dkg.vss);
         while aggregated.coeffs[0] == G1::zero() {
-            let (dkg, _) = setup_dkg(0);
+            let (dkg, _) = setup_dkg();
             aggregated = aggregate(&dkg.vss);
         }
         aggregated.coeffs[0] = G1::zero();


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
-  2

**What this does:**
- DKG now operates under relaxed ceremony constraints, where instead of `n-of-m` we allow for `n-of-[m, validators.len()]` to be considered a successful ceremony
- In this new regime, the old `shares_num` is effectively replaced by `validators.len()`, and from now on `shares_num` denotes the minimum number of shares (or validators) that the DKG ceremony accommodates 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- Based on https://github.com/nucypher/ferveo/pull/166 - Please review it first
