### PR TITLE
Refactor DKG parameters into a `DkgParams`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "serde",
  "serde_with",
  "subproductdomain-pre-release",
+ "test-case",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-derive",
@@ -1879,6 +1880,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+ "test-case-core",
 ]
 
 [[package]]

--- a/ferveo-tdec/benches/tpke.rs
+++ b/ferveo-tdec/benches/tpke.rs
@@ -189,7 +189,7 @@ pub fn bench_create_decryption_share(c: &mut Criterion) {
                         .map(|ctx| {
                             // Using create_unchecked here to avoid the cost of verifying the ciphertext
                             DecryptionShareSimple::create_unchecked(
-                                &ctx.validator_private_key,
+                                &ctx.setup_params.b,
                                 &ctx.private_key_share,
                                 &setup.shared.ciphertext.header().unwrap(),
                             )

--- a/ferveo-tdec/src/context.rs
+++ b/ferveo-tdec/src/context.rs
@@ -29,7 +29,7 @@ pub struct PublicDecryptionContextSimple<E: Pairing> {
 
 #[derive(Clone, Debug)]
 pub struct SetupParams<E: Pairing> {
-    pub b: E::ScalarField,
+    pub b: E::ScalarField, // Validator private key
     pub b_inv: E::ScalarField,
     pub g: E::G1Affine,
     pub g_inv: E::G1Prepared,
@@ -71,8 +71,6 @@ pub struct PrivateDecryptionContextSimple<E: Pairing> {
     pub setup_params: SetupParams<E>,
     pub private_key_share: PrivateKeyShare<E>,
     pub public_decryption_contexts: Vec<PublicDecryptionContextSimple<E>>,
-    // TODO: Remove/replace with `setup_params.b` after refactoring
-    pub validator_private_key: E::ScalarField,
 }
 
 impl<E: Pairing> PrivateDecryptionContextSimple<E> {
@@ -82,7 +80,7 @@ impl<E: Pairing> PrivateDecryptionContextSimple<E> {
         aad: &[u8],
     ) -> Result<DecryptionShareSimple<E>> {
         DecryptionShareSimple::create(
-            &self.validator_private_key,
+            &self.setup_params.b,
             &self.private_key_share,
             ciphertext_header,
             aad,
@@ -104,7 +102,7 @@ impl<E: Pairing> PrivateDecryptionContextSimple<E> {
 
         DecryptionSharePrecomputed::new(
             self.index,
-            &self.validator_private_key,
+            &self.setup_params.b,
             &self.private_key_share,
             ciphertext_header,
             aad,

--- a/ferveo-tdec/src/lib.rs
+++ b/ferveo-tdec/src/lib.rs
@@ -243,7 +243,6 @@ pub mod test_common {
                     h,
                 },
                 private_key_share,
-                validator_private_key: b,
                 public_decryption_contexts: vec![],
             });
             public_contexts.push(PublicDecryptionContextSimple::<E> {

--- a/ferveo-wasm/examples/node/src/main.test.ts
+++ b/ferveo-wasm/examples/node/src/main.test.ts
@@ -22,11 +22,8 @@ const genEthAddr = (i: number) => {
   return EthereumAddress.fromString(ethAddr);
 };
 
-function setupTest() {
-  const tau = 1;
-  const sharesNum = 4;
-  const threshold = Math.floor((sharesNum * 2) / 3);
-
+const tau = 1;
+function setupTest(sharesNum :number, threshold: number) {
   const validatorKeypairs: Keypair[] = [];
   const validators: Validator[] = [];
   for (let i = 0; i < sharesNum; i++) {
@@ -63,9 +60,6 @@ function setupTest() {
   const ciphertext = ferveoEncrypt(msg, aad, dkg.publicKey());
 
   return {
-    tau,
-    sharesNum,
-    threshold,
     validatorKeypairs,
     validators,
     dkg,
@@ -79,17 +73,16 @@ function setupTest() {
 // This test suite replicates tests from ferveo-wasm/tests/node.rs
 describe("ferveo-wasm", () => {
   it("simple tdec variant", () => {
+      const sharesNum = 4;
+      const threshold = 3;
     const {
-      tau,
-      sharesNum,
-      threshold,
       validatorKeypairs,
       validators,
       messages,
       msg,
       aad,
       ciphertext,
-    } = setupTest();
+    } = setupTest(sharesNum, threshold);
 
     // Having aggregated the transcripts, the validators can now create decryption shares
     const decryptionShares: DecryptionShareSimple[] = [];
@@ -128,17 +121,16 @@ describe("ferveo-wasm", () => {
   });
 
   it("precomputed tdec variant", () => {
+      const sharesNum = 4;
+        const threshold = sharesNum; // threshold is equal to sharesNum in precomputed variant
     const {
-      tau,
-      sharesNum,
-      threshold,
       validatorKeypairs,
       validators,
       messages,
       msg,
       aad,
       ciphertext,
-    } = setupTest();
+    } = setupTest(sharesNum, threshold);
 
     // Having aggregated the transcripts, the validators can now create decryption shares
     const decryptionShares: DecryptionSharePrecomputed[] = [];

--- a/ferveo-wasm/tests/node.rs
+++ b/ferveo-wasm/tests/node.rs
@@ -8,8 +8,8 @@ use wasm_bindgen_test::*;
 
 type TestSetup = (
     u32,
-    usize,
-    usize,
+    u32,
+    u32,
     Vec<Keypair>,
     Vec<Validator>,
     ValidatorArray,
@@ -21,11 +21,12 @@ type TestSetup = (
 
 fn setup_dkg() -> TestSetup {
     let tau = 1;
-    let shares_num = 16;
+    let shares_num: u32 = 16;
     let security_threshold = shares_num * 2 / 3;
 
-    let validator_keypairs =
-        (0..shares_num).map(gen_keypair).collect::<Vec<Keypair>>();
+    let validator_keypairs = (0..shares_num as usize)
+        .map(gen_keypair)
+        .collect::<Vec<Keypair>>();
     let validators = validator_keypairs
         .iter()
         .enumerate()
@@ -38,8 +39,8 @@ fn setup_dkg() -> TestSetup {
     let messages = validators.iter().map(|sender| {
         let dkg = Dkg::new(
             tau,
-            shares_num as u32,
-            security_threshold as u32,
+            shares_num,
+            security_threshold,
             &validators_js,
             sender,
         )
@@ -54,8 +55,8 @@ fn setup_dkg() -> TestSetup {
 
     let mut dkg = Dkg::new(
         tau,
-        shares_num as u32,
-        security_threshold as u32,
+        shares_num,
+        security_threshold,
         &validators_js,
         &validators[0],
     )
@@ -112,8 +113,8 @@ fn tdec_simple() {
         .map(|(validator, keypair)| {
             let mut dkg = Dkg::new(
                 tau,
-                shares_num as u32,
-                security_threshold as u32,
+                shares_num,
+                security_threshold,
                 &validators_js,
                 &validator,
             )
@@ -166,8 +167,8 @@ fn tdec_precomputed() {
         .map(|(validator, keypair)| {
             let mut dkg = Dkg::new(
                 tau,
-                shares_num as u32,
-                security_threshold as u32,
+                shares_num,
+                security_threshold,
                 &validators_js,
                 &validator,
             )

--- a/ferveo-wasm/tests/node.rs
+++ b/ferveo-wasm/tests/node.rs
@@ -7,9 +7,6 @@ use itertools::zip_eq;
 use wasm_bindgen_test::*;
 
 type TestSetup = (
-    u32,
-    u32,
-    u32,
     Vec<Keypair>,
     Vec<Validator>,
     ValidatorArray,
@@ -19,11 +16,9 @@ type TestSetup = (
     Ciphertext,
 );
 
-fn setup_dkg() -> TestSetup {
-    let tau = 1;
-    let shares_num: u32 = 16;
-    let security_threshold = shares_num * 2 / 3;
+const TAU: u32 = 0;
 
+fn setup_dkg(shares_num: u32, security_threshold: u32) -> TestSetup {
     let validator_keypairs = (0..shares_num as usize)
         .map(gen_keypair)
         .collect::<Vec<Keypair>>();
@@ -38,7 +33,7 @@ fn setup_dkg() -> TestSetup {
     // validator, including themselves
     let messages = validators.iter().map(|sender| {
         let dkg = Dkg::new(
-            tau,
+            TAU,
             shares_num,
             security_threshold,
             &validators_js,
@@ -54,7 +49,7 @@ fn setup_dkg() -> TestSetup {
     // every validator can aggregate the transcripts
 
     let mut dkg = Dkg::new(
-        tau,
+        TAU,
         shares_num,
         security_threshold,
         &validators_js,
@@ -80,9 +75,6 @@ fn setup_dkg() -> TestSetup {
     let ciphertext = ferveo_encrypt(&msg, &aad, &dkg.public_key()).unwrap();
 
     (
-        tau,
-        shares_num,
-        security_threshold,
         validator_keypairs,
         validators,
         validators_js,
@@ -95,10 +87,9 @@ fn setup_dkg() -> TestSetup {
 
 #[wasm_bindgen_test]
 fn tdec_simple() {
+    let shares_num = 16;
+    let security_threshold = 10;
     let (
-        tau,
-        shares_num,
-        security_threshold,
         validator_keypairs,
         validators,
         validators_js,
@@ -106,13 +97,13 @@ fn tdec_simple() {
         msg,
         aad,
         ciphertext,
-    ) = setup_dkg();
+    ) = setup_dkg(shares_num, security_threshold);
 
     // Having aggregated the transcripts, the validators can now create decryption shares
     let decryption_shares = zip_eq(validators, validator_keypairs)
         .map(|(validator, keypair)| {
             let mut dkg = Dkg::new(
-                tau,
+                TAU,
                 shares_num,
                 security_threshold,
                 &validators_js,
@@ -149,10 +140,9 @@ fn tdec_simple() {
 
 #[wasm_bindgen_test]
 fn tdec_precomputed() {
+    let shares_num = 16;
+    let security_threshold = shares_num; // Must be equal to shares_num in precomputed variant
     let (
-        tau,
-        shares_num,
-        security_threshold,
         validator_keypairs,
         validators,
         validators_js,
@@ -160,13 +150,13 @@ fn tdec_precomputed() {
         msg,
         aad,
         ciphertext,
-    ) = setup_dkg();
+    ) = setup_dkg(shares_num, security_threshold);
 
     // Having aggregated the transcripts, the validators can now create decryption shares
     let decryption_shares = zip_eq(validators, validator_keypairs)
         .map(|(validator, keypair)| {
             let mut dkg = Dkg::new(
-                tau,
+                TAU,
                 shares_num,
                 security_threshold,
                 &validators_js,

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -51,6 +51,7 @@ wasm-bindgen-derive = { version = "0.2.1", optional = true }
 criterion = "0.3" # supports pprof, # TODO: Figure out if/how we can update to 0.4
 digest = { version = "0.10.0", features = ["alloc"] }
 pprof = { version = "0.6", features = ["flamegraph", "criterion"] }
+test-case = "3.3.1"
 
 # WASM bindings
 console_error_panic_hook = "0.1.7"

--- a/ferveo/benches/benchmarks/block_proposer.rs
+++ b/ferveo/benches/benchmarks/block_proposer.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+// TODO: Currently not maintained - see mod.rs
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use ark_bls12_381::*;

--- a/ferveo/benches/benchmarks/mod.rs
+++ b/ferveo/benches/benchmarks/mod.rs
@@ -1,4 +1,5 @@
-//pub mod block_proposer;
+// We disabled the following benchmarks because their outcomes were not relevant to us at the time.
+// pub mod block_proposer;
 // pub mod pairing;
 pub mod eval_domain;
 pub mod validity_checks;

--- a/ferveo/benches/benchmarks/validity_checks.rs
+++ b/ferveo/benches/benchmarks/validity_checks.rs
@@ -45,11 +45,7 @@ fn setup_dkg(
     let me = validators[validator].clone();
     PubliclyVerifiableDkg::new(
         &validators,
-        &DkgParams {
-            tau: 0,
-            security_threshold: shares_num / 3,
-            shares_num,
-        },
+        &DkgParams::new(0, shares_num / 3, shares_num).unwrap(),
         &me,
     )
     .expect("Setup failed")

--- a/ferveo/examples/bench_primitives_size.rs
+++ b/ferveo/examples/bench_primitives_size.rs
@@ -80,11 +80,7 @@ fn setup_dkg(
     let me = validators[validator].clone();
     PubliclyVerifiableDkg::new(
         &validators,
-        &DkgParams {
-            tau: 0,
-            security_threshold,
-            shares_num,
-        },
+        &DkgParams::new(0, security_threshold, shares_num).unwrap(),
         &me,
     )
     .expect("Setup failed")

--- a/ferveo/src/api.rs
+++ b/ferveo/src/api.rs
@@ -309,6 +309,14 @@ impl AggregatedTranscript {
         aad: &[u8],
         validator_keypair: &Keypair,
     ) -> Result<DecryptionSharePrecomputed> {
+        if dkg.0.dkg_params.shares_num()
+            != dkg.0.dkg_params.security_threshold()
+        {
+            return Err(Error::InvalidDkgParametersForPrecomputedVariant(
+                dkg.0.dkg_params.shares_num(),
+                dkg.0.dkg_params.security_threshold(),
+            ));
+        }
         let domain_points: Vec<_> = dkg
             .0
             .domain
@@ -455,8 +463,6 @@ mod test_ferveo_api {
         let rng = &mut StdRng::seed_from_u64(0);
 
         // In precomputed variant, the security threshold is equal to the number of shares
-        // TODO: Refactor DKG constructor to not require security threshold or this case.
-        //  Or figure out a different way to simplify the precomputed variant API.
         let security_threshold = shares_num;
 
         let (messages, validators, validator_keypairs) =

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -93,7 +93,17 @@ impl From<FerveoPythonError> for PyErr {
                 }
                 Error::InvalidVariant(variant) => {
                     InvalidVariant::new_err(variant.to_string())
-                }
+                },
+                Error::InvalidDkgParameters(num_shares, security_threshold) => {
+                    InvalidDkgParameters::new_err(format!(
+                        "num_shares: {num_shares}, security_threshold: {security_threshold}"
+                    ))
+                },
+                Error::InvalidShareIndex(index) => {
+                    InvalidShareIndex::new_err(format!(
+                        "{index}"
+                    ))
+                },
             },
             _ => default(),
         }
@@ -128,6 +138,8 @@ create_exception!(exceptions, ValidatorPublicKeyMismatch, PyValueError);
 create_exception!(exceptions, SerializationError, PyValueError);
 create_exception!(exceptions, InvalidByteLength, PyValueError);
 create_exception!(exceptions, InvalidVariant, PyValueError);
+create_exception!(exceptions, InvalidDkgParameters, PyValueError);
+create_exception!(exceptions, InvalidShareIndex, PyValueError);
 
 fn from_py_bytes<T: FromBytes>(bytes: &[u8]) -> PyResult<T> {
     T::from_bytes(bytes)

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -739,7 +739,7 @@ pub fn make_ferveo_py_module(py: Python<'_>, m: &PyModule) -> PyResult<()> {
 mod test_ferveo_python {
     use itertools::izip;
 
-    use crate::bindings_python::*;
+    use crate::{bindings_python::*, test_common::*};
 
     type TestInputs = (Vec<ValidatorMessage>, Vec<Validator>, Vec<Keypair>);
 
@@ -785,21 +785,19 @@ mod test_ferveo_python {
 
     #[test]
     fn test_server_api_tdec_precomputed() {
-        let tau = 1;
-        let shares_num = 4;
         // In precomputed variant, the security threshold is equal to the number of shares
-        let security_threshold = shares_num;
+        let security_threshold = SHARES_NUM;
 
         let (messages, validators, validator_keypairs) =
-            make_test_inputs(tau, security_threshold, shares_num);
+            make_test_inputs(TAU, security_threshold, SHARES_NUM);
 
         // Now that every validator holds a dkg instance and a transcript for every other validator,
         // every validator can aggregate the transcripts
 
         let me = validators[0].clone();
         let mut dkg = Dkg::new(
-            tau,
-            shares_num,
+            TAU,
+            SHARES_NUM,
             security_threshold,
             validators.clone(),
             &me,
@@ -811,24 +809,22 @@ mod test_ferveo_python {
         let pvss_aggregated =
             dkg.aggregate_transcripts(messages.clone()).unwrap();
         assert!(pvss_aggregated
-            .verify(shares_num, messages.clone())
+            .verify(SHARES_NUM, messages.clone())
             .unwrap());
 
         // At this point, any given validator should be able to provide a DKG public key
         let dkg_public_key = dkg.public_key();
 
         // In the meantime, the client creates a ciphertext and decryption request
-        let msg: &[u8] = "my-msg".as_bytes();
-        let aad: &[u8] = "my-aad".as_bytes();
-        let ciphertext = encrypt(msg, aad, &dkg_public_key).unwrap();
+        let ciphertext = encrypt(MSG, AAD, &dkg_public_key).unwrap();
 
         // Having aggregated the transcripts, the validators can now create decryption shares
         let decryption_shares: Vec<_> = izip!(&validators, &validator_keypairs)
             .map(|(validator, validator_keypair)| {
                 // Each validator holds their own instance of DKG and creates their own aggregate
                 let mut dkg = Dkg::new(
-                    tau,
-                    shares_num,
+                    TAU,
+                    SHARES_NUM,
                     security_threshold,
                     validators.clone(),
                     validator,
@@ -837,13 +833,13 @@ mod test_ferveo_python {
                 let aggregate =
                     dkg.aggregate_transcripts(messages.clone()).unwrap();
                 assert!(pvss_aggregated
-                    .verify(shares_num, messages.clone())
+                    .verify(SHARES_NUM, messages.clone())
                     .is_ok());
                 aggregate
                     .create_decryption_share_precomputed(
                         &dkg,
                         &ciphertext.header().unwrap(),
-                        aad,
+                        AAD,
                         validator_keypair,
                     )
                     .unwrap()
@@ -857,56 +853,50 @@ mod test_ferveo_python {
             combine_decryption_shares_precomputed(decryption_shares);
 
         let plaintext =
-            decrypt_with_shared_secret(&ciphertext, aad, &shared_secret)
+            decrypt_with_shared_secret(&ciphertext, AAD, &shared_secret)
                 .unwrap();
-        assert_eq!(plaintext, msg);
+        assert_eq!(plaintext, MSG);
     }
 
     #[test]
     fn test_server_api_tdec_simple() {
-        let tau = 1;
-        let shares_num = 4;
-        let security_threshold = 3;
-
         let (messages, validators, validator_keypairs) =
-            make_test_inputs(tau, security_threshold, shares_num);
+            make_test_inputs(TAU, SECURITY_THRESHOLD, SHARES_NUM);
 
         // Now that every validator holds a dkg instance and a transcript for every other validator,
         // every validator can aggregate the transcripts
         let me = validators[0].clone();
         let mut dkg = Dkg::new(
-            tau,
-            shares_num,
-            security_threshold,
+            TAU,
+            SHARES_NUM,
+            SECURITY_THRESHOLD,
             validators.clone(),
             &me,
         )
         .unwrap();
 
         // Lets say that we've only receives `security_threshold` transcripts
-        let messages = messages[..security_threshold as usize].to_vec();
+        let messages = messages[..SECURITY_THRESHOLD as usize].to_vec();
         let pvss_aggregated =
             dkg.aggregate_transcripts(messages.clone()).unwrap();
         assert!(pvss_aggregated
-            .verify(shares_num, messages.clone())
+            .verify(SHARES_NUM, messages.clone())
             .unwrap());
 
         // At this point, any given validator should be able to provide a DKG public key
         let dkg_public_key = dkg.public_key();
 
         // In the meantime, the client creates a ciphertext and decryption request
-        let msg: &[u8] = "my-msg".as_bytes();
-        let aad: &[u8] = "my-aad".as_bytes();
-        let ciphertext = encrypt(msg, aad, &dkg_public_key).unwrap();
+        let ciphertext = encrypt(MSG, AAD, &dkg_public_key).unwrap();
 
         // Having aggregated the transcripts, the validators can now create decryption shares
         let decryption_shares: Vec<_> = izip!(&validators, &validator_keypairs)
             .map(|(validator, validator_keypair)| {
                 // Each validator holds their own instance of DKG and creates their own aggregate
                 let mut dkg = Dkg::new(
-                    tau,
-                    shares_num,
-                    security_threshold,
+                    TAU,
+                    SHARES_NUM,
+                    SECURITY_THRESHOLD,
                     validators.clone(),
                     validator,
                 )
@@ -914,13 +904,13 @@ mod test_ferveo_python {
                 let aggregate =
                     dkg.aggregate_transcripts(messages.clone()).unwrap();
                 assert!(aggregate
-                    .verify(shares_num, messages.clone())
+                    .verify(SHARES_NUM, messages.clone())
                     .unwrap());
                 aggregate
                     .create_decryption_share_simple(
                         &dkg,
                         &ciphertext.header().unwrap(),
-                        aad,
+                        AAD,
                         validator_keypair,
                     )
                     .unwrap()
@@ -933,8 +923,8 @@ mod test_ferveo_python {
         let shared_secret = combine_decryption_shares_simple(decryption_shares);
 
         let plaintext =
-            decrypt_with_shared_secret(&ciphertext, aad, &shared_secret)
+            decrypt_with_shared_secret(&ciphertext, AAD, &shared_secret)
                 .unwrap();
-        assert_eq!(plaintext, msg);
+        assert_eq!(plaintext, MSG);
     }
 }

--- a/ferveo/src/bindings_python.rs
+++ b/ferveo/src/bindings_python.rs
@@ -104,6 +104,11 @@ impl From<FerveoPythonError> for PyErr {
                         "{index}"
                     ))
                 },
+                Error::InvalidDkgParametersForPrecomputedVariant(num_shares, security_threshold) => {
+                    InvalidDkgParameters::new_err(format!(
+                        "num_shares: {num_shares}, security_threshold: {security_threshold}"
+                    ))
+                },
             },
             _ => default(),
         }

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -510,15 +510,13 @@ impl AggregatedTranscript {
     #[wasm_bindgen]
     pub fn verify(
         &self,
-        shares_num: usize,
+        shares_num: u32,
         messages: &ValidatorMessageArray,
     ) -> JsResult<bool> {
         set_panic_hook();
         let messages = unwrap_messages_js(messages)?;
-        let is_valid = self
-            .0
-            .verify(shares_num as u32, &messages)
-            .map_err(map_js_err)?;
+        let is_valid =
+            self.0.verify(shares_num, &messages).map_err(map_js_err)?;
         Ok(is_valid)
     }
 

--- a/ferveo/src/bindings_wasm.rs
+++ b/ferveo/src/bindings_wasm.rs
@@ -595,7 +595,6 @@ impl Keypair {
     }
 }
 
-/// Factory functions for testing
 pub mod test_common {
     use crate::bindings_wasm::*;
 

--- a/ferveo/src/dkg.rs
+++ b/ferveo/src/dkg.rs
@@ -508,17 +508,17 @@ mod test_dealing {
     fn test_pvss_dealing() {
         let rng = &mut ark_std::test_rng();
 
+        // Create a test DKG instance
+        let (mut dkg, _) = setup_dkg(0);
+
         // Gather everyone's transcripts
         let mut messages = vec![];
-        for i in 0..4 {
-            let (mut dkg, _) = setup_dkg(i);
+        for i in 0..dkg.dkg_params.shares_num() {
+            let (mut dkg, _) = setup_dkg(i as usize);
             let message = dkg.share(rng).unwrap();
             let sender = dkg.me.validator.clone();
             messages.push((sender, message));
         }
-
-        // Create a test DKG instance
-        let (mut dkg, _) = setup_dkg(0);
 
         let mut expected = 0u32;
         for (sender, pvss) in messages.iter() {

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -101,6 +101,12 @@ pub enum Error {
 
     #[error("Invalid variant: {0}")]
     InvalidVariant(String),
+
+    #[error("Invalid DKG parameters: number of shares {0}, threshold {1}")]
+    InvalidDkgParameters(u32, u32),
+
+    #[error("Invalid share index: {0}")]
+    InvalidShareIndex(u32),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -410,7 +416,7 @@ mod test_dkg_full {
                     &domain_points,
                     &dkg.pvss_params.h.into_affine(),
                     &x_r,
-                    dkg.dkg_params.security_threshold as usize,
+                    dkg.dkg_params.security_threshold() as usize,
                     rng,
                 );
                 (v_addr.clone(), deltas_i)
@@ -439,11 +445,13 @@ mod test_dkg_full {
                 // Creates updated private key shares
                 // TODO: Why not using dkg.aggregate()?
                 let pvss_aggregated = aggregate(&dkg.vss);
-                pvss_aggregated.update_private_key_share_for_recovery(
-                    &decryption_key,
-                    validator.share_index,
-                    updates_for_participant.as_slice(),
-                )
+                pvss_aggregated
+                    .update_private_key_share_for_recovery(
+                        &decryption_key,
+                        validator.share_index,
+                        updates_for_participant.as_slice(),
+                    )
+                    .unwrap()
             })
             .collect();
 
@@ -552,7 +560,7 @@ mod test_dkg_full {
                 let deltas_i = prepare_share_updates_for_refresh::<E>(
                     &domain_points,
                     &dkg.pvss_params.h.into_affine(),
-                    dkg.dkg_params.security_threshold as usize,
+                    dkg.dkg_params.security_threshold() as usize,
                     rng,
                 );
                 (v_addr.clone(), deltas_i)
@@ -582,11 +590,13 @@ mod test_dkg_full {
                 // Creates updated private key shares
                 // TODO: Why not using dkg.aggregate()?
                 let pvss_aggregated = aggregate(&dkg.vss);
-                pvss_aggregated.update_private_key_share_for_recovery(
-                    &decryption_key,
-                    validator.share_index,
-                    updates_for_participant.as_slice(),
-                )
+                pvss_aggregated
+                    .update_private_key_share_for_recovery(
+                        &decryption_key,
+                        validator.share_index,
+                        updates_for_participant.as_slice(),
+                    )
+                    .unwrap()
             })
             .collect();
 

--- a/ferveo/src/lib.rs
+++ b/ferveo/src/lib.rs
@@ -114,6 +114,10 @@ pub enum Error {
     /// Failed to access a share for a given share index
     #[error("Invalid share index: {0}")]
     InvalidShareIndex(u32),
+
+    /// Failed to produce a precomputed variant decryption share
+    #[error("Invalid DKG parameters for precomputed variant: number of shares {0}, threshold {1}")]
+    InvalidDkgParametersForPrecomputedVariant(u32, u32),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -462,11 +462,7 @@ mod test_pvss {
     use rand::seq::SliceRandom;
 
     use super::*;
-    use crate::{dkg::test_common::*, utils::is_sorted};
-
-    type ScalarField = <EllipticCurve as Pairing>::ScalarField;
-    type G1 = <EllipticCurve as Pairing>::G1Affine;
-    type G2 = <EllipticCurve as Pairing>::G2Affine;
+    use crate::{test_common::*, utils::is_sorted, DkgParams};
 
     /// Test the happy flow that a pvss with the correct form is created
     /// and that appropriate validations pass

--- a/ferveo/src/pvss.rs
+++ b/ferveo/src/pvss.rs
@@ -40,9 +40,6 @@ pub trait Aggregate {}
 /// Apply trait gate to Aggregated marker struct
 impl Aggregate for Aggregated {}
 
-// /// Type alias for non aggregated PVSS transcripts
-// pub type Pvss<E> = PubliclyVerifiableSS<E>;
-
 /// Type alias for aggregated PVSS transcripts
 pub type AggregatedPvss<E> = PubliclyVerifiableSS<E, Aggregated>;
 
@@ -138,7 +135,7 @@ impl<E: Pairing, T> PubliclyVerifiableSS<E, T> {
     ) -> Result<Self> {
         let phi = SecretPolynomial::<E>::new(
             s,
-            (dkg.dkg_params.security_threshold - 1) as usize,
+            (dkg.dkg_params.security_threshold() - 1) as usize,
             rng,
         );
 
@@ -311,19 +308,19 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         &self,
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
-    ) -> PrivateKeyShare<E> {
+    ) -> Result<PrivateKeyShare<E>> {
         // Decrypt private key shares https://nikkolasg.github.io/ferveo/pvss.html#validator-decryption-of-private-key-shares
         let private_key_share = self
             .shares
             .get(share_index)
-            .unwrap()
+            .ok_or(Error::InvalidShareIndex(share_index as u32))?
             .mul(
                 validator_decryption_key
                     .inverse()
                     .expect("Validator decryption key must have an inverse"),
             )
             .into_affine();
-        PrivateKeyShare { private_key_share }
+        Ok(PrivateKeyShare { private_key_share })
     }
 
     pub fn make_decryption_share_simple(
@@ -335,7 +332,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         g_inv: &E::G1Prepared,
     ) -> Result<DecryptionShareSimple<E>> {
         let private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
+            .decrypt_private_key_share(validator_decryption_key, share_index)?;
         DecryptionShareSimple::create(
             validator_decryption_key,
             &private_key_share,
@@ -356,7 +353,7 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         g_inv: &E::G1Prepared,
     ) -> Result<DecryptionSharePrecomputed<E>> {
         let private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
+            .decrypt_private_key_share(validator_decryption_key, share_index)?;
 
         // We use the `prepare_combine_simple` function to precompute the lagrange coefficients
         let lagrange_coeffs = prepare_combine_simple::<E>(domain_points);
@@ -379,13 +376,16 @@ impl<E: Pairing, T: Aggregate> PubliclyVerifiableSS<E, T> {
         validator_decryption_key: &E::ScalarField,
         share_index: usize,
         share_updates: &[E::G2],
-    ) -> PrivateKeyShare<E> {
+    ) -> Result<PrivateKeyShare<E>> {
         // Retrieves their private key share
         let private_key_share = self
-            .decrypt_private_key_share(validator_decryption_key, share_index);
+            .decrypt_private_key_share(validator_decryption_key, share_index)?;
 
         // And updates their share
-        apply_updates_to_private_share::<E>(&private_key_share, share_updates)
+        Ok(apply_updates_to_private_share::<E>(
+            &private_key_share,
+            share_updates,
+        ))
     }
 }
 
@@ -482,7 +482,7 @@ mod test_pvss {
         // Check that a polynomial of the correct degree was created
         assert_eq!(
             pvss.coeffs.len(),
-            dkg.dkg_params.security_threshold as usize
+            dkg.dkg_params.security_threshold() as usize
         );
         // Check that the correct number of shares were created
         assert_eq!(pvss.shares.len(), dkg.validators.len());
@@ -555,11 +555,7 @@ mod test_pvss {
         // And because of that the DKG should fail
         let result = PubliclyVerifiableDkg::new(
             &validators,
-            &DkgParams {
-                tau: 0,
-                security_threshold,
-                shares_num,
-            },
+            &DkgParams::new(0, security_threshold, shares_num).unwrap(),
             &me,
         );
         assert!(result.is_err());
@@ -578,7 +574,7 @@ mod test_pvss {
         // Check that a polynomial of the correct degree was created
         assert_eq!(
             aggregate.coeffs.len(),
-            dkg.dkg_params.security_threshold as usize
+            dkg.dkg_params.security_threshold() as usize
         );
         // Check that the correct number of shares were created
         assert_eq!(aggregate.shares.len(), dkg.validators.len());

--- a/ferveo/src/test_common.rs
+++ b/ferveo/src/test_common.rs
@@ -1,0 +1,110 @@
+/// Factory functions and variables for testing
+use std::str::FromStr;
+
+pub use ark_bls12_381::Bls12_381 as E;
+use ark_ec::pairing::Pairing;
+use ferveo_common::Keypair;
+use rand::seq::SliceRandom;
+
+use crate::{DkgParams, EthereumAddress, PubliclyVerifiableDkg, Validator};
+
+pub type ScalarField = <E as Pairing>::ScalarField;
+pub type G1 = <E as Pairing>::G1Affine;
+pub type G2 = <E as Pairing>::G2Affine;
+pub type TargetField = <E as Pairing>::TargetField;
+
+pub const TAU: u32 = 0;
+pub const MSG: &[u8] = b"my-msg";
+pub const AAD: &[u8] = b"my-aad";
+pub const SECURITY_THRESHOLD: u32 = 3;
+pub const SHARES_NUM: u32 = 4;
+
+pub fn gen_keypairs(n: u32) -> Vec<Keypair<E>> {
+    let rng = &mut ark_std::test_rng();
+    (0..n).map(|_| Keypair::<E>::new(rng)).collect()
+}
+
+pub fn gen_address(i: usize) -> EthereumAddress {
+    EthereumAddress::from_str(&format!("0x{i:040}")).unwrap()
+}
+
+pub fn gen_validators(keypairs: &[Keypair<E>]) -> Vec<Validator<E>> {
+    keypairs
+        .iter()
+        .enumerate()
+        .map(|(i, keypair)| Validator {
+            address: gen_address(i),
+            public_key: keypair.public_key(),
+        })
+        .collect()
+}
+
+pub type TestSetup = (PubliclyVerifiableDkg<E>, Vec<Keypair<E>>);
+
+pub fn setup_dkg_for_n_validators(
+    security_threshold: u32,
+    shares_num: u32,
+    my_validator_index: usize,
+) -> TestSetup {
+    let keypairs = gen_keypairs(shares_num);
+    let mut validators = gen_validators(keypairs.as_slice());
+    validators.sort();
+    let me = validators[my_validator_index].clone();
+    let dkg = PubliclyVerifiableDkg::new(
+        &validators,
+        &DkgParams::new(TAU, security_threshold, shares_num).unwrap(),
+        &me,
+    )
+    .expect("Setup failed");
+    (dkg, keypairs)
+}
+
+/// Create a test dkg
+///
+/// The [`crate::dkg::test_dkg_init`] module checks correctness of this setup
+pub fn setup_dkg(my_validator_index: usize) -> TestSetup {
+    setup_dkg_for_n_validators(
+        SECURITY_THRESHOLD,
+        SHARES_NUM,
+        my_validator_index,
+    )
+}
+
+/// Set up a dkg with enough pvss transcripts to meet the threshold
+///
+/// The correctness of this function is tested in the module [`crate::dkg::test_dealing`]
+pub fn setup_dealt_dkg() -> TestSetup {
+    setup_dealt_dkg_with(SECURITY_THRESHOLD, SHARES_NUM)
+}
+
+pub fn setup_dealt_dkg_with(
+    security_threshold: u32,
+    shares_num: u32,
+) -> TestSetup {
+    let rng = &mut ark_std::test_rng();
+
+    // Gather everyone's transcripts
+    let mut messages: Vec<_> = (0..shares_num)
+        .map(|my_index| {
+            let (mut dkg, _) = setup_dkg_for_n_validators(
+                security_threshold,
+                shares_num,
+                my_index as usize,
+            );
+            let me = dkg.me.validator.clone();
+            let message = dkg.share(rng).unwrap();
+            (me, message)
+        })
+        .collect();
+
+    // Create a test DKG instance
+    let (mut dkg, keypairs) =
+        setup_dkg_for_n_validators(security_threshold, shares_num, 0);
+
+    // The ordering of messages should not matter
+    messages.shuffle(rng);
+    messages.iter().for_each(|(sender, message)| {
+        dkg.apply_message(sender, message).expect("Setup failed");
+    });
+    (dkg, keypairs)
+}

--- a/ferveo/src/validator.rs
+++ b/ferveo/src/validator.rs
@@ -54,6 +54,7 @@ impl<E: Pairing> PartialOrd for Validator<E> {
 }
 
 impl<E: Pairing> Ord for Validator<E> {
+    // Validators are ordered by their address only
     fn cmp(&self, other: &Self) -> Ordering {
         self.address.cmp(&other.address)
     }


### PR DESCRIPTION
**Type of PR:**
- Refactor

**Required reviews:** 
- 1

**What this does:**
- Refactors DKG parameters usage and validation into `DkgParams`
- Uses `test_case` crate in tests to duplicate test scenarios
- Refactors shared test utils and variables into `ferveo::test_common` module
- Replaces some panics with proper error handling and error types
- Fixes some outstanding TODOs

**Notes for reviewers:**
- This PR contains no API changes. I opted to address these changes here to avoid bundling them with PRs that contain functional changes, making it easier to review them. 
- Reviewing commit by commit should be easier
- Based on https://github.com/nucypher/ferveo/pull/166 - Please review it first
