### PR TITLE
Move shared dependencies to the workspace crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,33 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,29 +335,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags",
- "clap_lex",
- "indexmap",
- "textwrap 0.16.0",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -445,8 +391,8 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap 2.34.0",
- "criterion-plot 0.4.5",
+ "clap",
+ "criterion-plot",
  "csv",
  "itertools",
  "lazy_static",
@@ -464,46 +410,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
-dependencies = [
- "anes",
- "atty",
- "cast",
- "ciborium",
- "clap 3.2.25",
- "criterion-plot 0.5.0",
- "itertools",
- "lazy_static",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "criterion-plot"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -767,7 +677,7 @@ dependencies = [
  "ark-std",
  "bincode",
  "console_error_panic_hook",
- "criterion 0.3.6",
+ "criterion",
  "derive_more",
  "digest",
  "ferveo-common-pre-release",
@@ -814,7 +724,7 @@ dependencies = [
  "ark-std",
  "bincode",
  "chacha20poly1305",
- "criterion 0.4.0",
+ "criterion",
  "ferveo-common-pre-release",
  "hex",
  "itertools",
@@ -1284,12 +1194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,7 +1271,7 @@ checksum = "55f35f865aa964be21fcde114cbd1cfbd9bf8a471460ed965b0f84f96c711401"
 dependencies = [
  "backtrace",
  "cfg-if",
- "criterion 0.3.6",
+ "criterion",
  "findshlibs",
  "inferno",
  "lazy_static",
@@ -1923,12 +1827,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,47 @@ members = [
     "subproductdomain",
 ]
 
+[workspace.dependencies]
+anyhow = "1.0.47"
+ark-bls12-381 = "0.4.0"
+ark-ec = "0.4"
+ark-ff = "0.4"
+ark-poly = "0.4"
+ark-serialize = "0.4"
+ark-std = "0.4"
+bincode = "1.3.3"
+chacha20poly1305 = "0.10.1"
+criterion = "0.3"
+console_error_panic_hook = "0.1.7"
+derive_more = { version = "0.99", default-features = false }
+digest = "0.10.0"
+ferveo-common = { path = "ferveo-common" }
+ferveo-tdec = { path = "ferveo-tdec" }
+generic-array = "0.14.7"
+getrandom = "0.2"
+hex = "0.4"
+itertools = "0.10.5"
+js-sys = "0.3.63"
+measure_time = "0.8"
+miracl_core = "=2.3.0"
+pprof = "0.6"
+pyo3 = "0.18.2"
+pyo3-build-config = "*"
+rand = "0.8"
+rand_core = "0.6.4"
+rand_old =  { package = "rand", version = "0.7" } # TODO: Used by benchmarks/pairing.rs, update to rand = "0.8" when possible
+serde = "1.0"
+serde_bytes = "0.11.9"
+serde_with = "2.2.0"
+sha2 = "0.10.6"
+subproductdomain = { path = "subproductdomain" }
+test-case = "3.3.1"
+thiserror = "1.0"
+wasm-bindgen = "0.2.86"
+wasm-bindgen-derive = "0.2.1"
+wasm-bindgen-test = "0.3.28"
+zeroize = "1.6.0"
+
 [profile.bench]
 opt-level = 3
 debug = true

--- a/ferveo-common/Cargo.toml
+++ b/ferveo-common/Cargo.toml
@@ -7,14 +7,14 @@ authors = ["Heliax AG <hello@heliax.dev>", "Piotr Roslaniec <p.roslaniec@gmail.c
 description = "Common types and traits for Ferveo"
 
 [dependencies]
-ark-ec = "0.4"
-ark-serialize = { version = "0.4", features = ["derive"] }
-ark-std = "0.4"
-bincode = "1.3.3"
-generic-array = "0.14.7"
-rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.2.0"
+ark-ec = { workspace = true }
+ark-serialize = { workspace = true, features = ["derive"] }
+ark-std = { workspace = true }
+bincode = { workspace = true }
+generic-array = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true }
 
 [dev-dependencies]
-ark-bls12-381 = "0.4.0"
+ark-bls12-381 = { workspace = true }

--- a/ferveo-python/Cargo.toml
+++ b/ferveo-python/Cargo.toml
@@ -15,7 +15,7 @@ default = ["extension-module"]
 
 [dependencies]
 ferveo = { package = "ferveo-pre-release", path = "../ferveo", features = ["bindings-python"] }
-pyo3 = "0.18.2"
+pyo3 = { workspace = true }
 
 [build-dependencies]
-pyo3-build-config = "*"
+pyo3-build-config = { workspace = true }

--- a/ferveo-tdec/Cargo.toml
+++ b/ferveo-tdec/Cargo.toml
@@ -16,30 +16,30 @@ test-common = []
 api = []
 
 [dependencies]
-ark-bls12-381 = "0.4"
-ark-ec = "0.4"
-ark-ff = "0.4"
-ark-poly = "0.4"
-ark-serialize = "0.4"
-ark-std = "0.4"
-bincode = "1.3.3"
-chacha20poly1305 = "0.10.1"
+ark-bls12-381 = { workspace = true }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-poly = { workspace = true }
+ark-serialize = { workspace = true }
+ark-std = { workspace = true }
+bincode = { workspace = true }
+chacha20poly1305 = { workspace = true }
 ferveo-common = { package = "ferveo-common-pre-release", path = "../ferveo-common", version = "^0.1.1" }
-itertools = "0.10"
-miracl_core = "=2.3.0"
-rand = "0.8"
-rand_core = "0.6"
-serde = { version = "1.0", features = ["derive"] }
-serde_bytes = "0.11.9"
-serde_with = "2.0.1"
-sha2 = "0.10.6"
+itertools = { workspace = true }
+miracl_core = { workspace = true }
+rand = { workspace = true }
+rand_core = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+serde_with = { workspace = true }
+sha2 = { workspace = true }
 subproductdomain = { package = "subproductdomain-pre-release", path = "../subproductdomain", version = "^0.1.0" }
-thiserror = "1.0"
-zeroize = "1.6.0"
+thiserror = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
-hex = "=0.4.3"
+criterion = { workspace = true, features = ["html_reports"] }
+hex = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/ferveo-wasm/Cargo.toml
+++ b/ferveo-wasm/Cargo.toml
@@ -17,6 +17,6 @@ crate-type = ["cdylib", "rlib"]
 ferveo = { package = "ferveo-pre-release", path = "../ferveo", features = ["bindings-wasm"] }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.28"
-itertools = "0.10.5"
+wasm-bindgen-test = { workspace = true }
+itertools = { workspace = true }
 

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -14,49 +14,43 @@ authors = ["Heliax AG <hello@heliax.dev>", "Piotr Roslaniec <p.roslaniec@gmail.c
 bench = false
 
 [dependencies]
-ark-bls12-381 = "0.4"
-ark-ec = "0.4"
-ark-ff = "0.4"
-ark-poly = "0.4"
-ark-serialize = "0.4"
-ark-std = "0.4"
-bincode = "1.3"
+ark-bls12-381 = { workspace = true }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-poly = { workspace = true }
+ark-serialize = { workspace = true }
+ark-std = { workspace = true }
+bincode = { workspace = true }
 ferveo-common = { package = "ferveo-common-pre-release", path = "../ferveo-common", version = "^0.1.1" }
-ferveo-tdec = { package = "ferveo-tdec", path = "../ferveo-tdec", features = ["api", "test-common"], version = "^0.2.0" }
-hex = "0.4.3"
-itertools = "0.10.5"
-measure_time = "0.8"
-rand = "0.8"
-rand_core = "0.6.4"
-rand_old = { package = "rand", version = "0.7" } # used by benchmarks/pairing.rs
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "2.2.0"
+ferveo-tdec = { workspace = true, features = ["api", "test-common"] }
+hex = { workspace = true }
+itertools = { workspace = true }
+measure_time = { workspace = true }
+rand = { workspace = true }
+rand_core = { workspace = true }
+rand_old = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true }
 subproductdomain = { package = "subproductdomain-pre-release", path = "../subproductdomain", version = "^0.1.0" }
-thiserror = "1.0"
-zeroize = { version = "1.6.0", default-features = false, features = ["derive"] }
-generic-array = "0.14.7"
-derive_more = { version = "0.99", default-features = false, features = ["from", "as_ref", "into"] }
-
-# Python bindings
-pyo3 = { version = "0.18.2", features = ["macros", "multiple-pymethods"], optional = true }
-
-# WASM bindings
-console_error_panic_hook = { version = "0.1.7", optional = true }
-getrandom = { version = "0.2", features = ["js"], optional = true }
-js-sys = { version = "0.3.63", optional = true }
-wasm-bindgen = { version = "0.2.86", optional = true }
-wasm-bindgen-derive = { version = "0.2.1", optional = true }
+thiserror = { workspace = true }
+zeroize = { workspace = true, features = ["derive"] }
+generic-array = { workspace = true }
+derive_more = { workspace = true, features = ["from", "as_ref", "into"] }
+pyo3 = { workspace = true, features = ["macros", "multiple-pymethods"], optional = true }
+console_error_panic_hook = { workspace = true, optional = true }
+getrandom = { workspace = true, features = ["js"], optional = true }
+js-sys = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = "0.3" # supports pprof, # TODO: Figure out if/how we can update to 0.4
-digest = { version = "0.10.0", features = ["alloc"] }
-pprof = { version = "0.6", features = ["flamegraph", "criterion"] }
-test-case = "3.3.1"
-
-# WASM bindings
-console_error_panic_hook = "0.1.7"
-serde = { version = "1.0", features = ["derive"] }
-wasm-bindgen = { version = "0.2.86", features = ["serde-serialize"] }
+criterion = { workspace = true }
+digest = { workspace = true, features = ["alloc"] }
+pprof = { workspace = true, features = ["flamegraph", "criterion"] }
+test-case = { workspace = true }
+console_error_panic_hook = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+wasm-bindgen = { workspace = true, features = ["serde-serialize"] }
 
 [features]
 bindings-python = ["pyo3"]

--- a/subproductdomain/Cargo.toml
+++ b/subproductdomain/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["Heliax AG <hello@heliax.dev>", "Piotr Roslaniec <p.roslaniec@gmail.c
 description = "Implements subproduct domain algorithm"
 
 [dependencies]
-anyhow = "1.0.47"
-ark-ec = "0.4"
-ark-ff = "0.4"
-ark-poly = "0.4"
-ark-std = "0.4"
+anyhow = { workspace = true }
+ark-ec = { workspace = true }
+ark-ff = { workspace = true }
+ark-poly = { workspace = true }
+ark-std = { workspace = true }
 
 [dev-dependencies]
-ark-bls12-381 = "0.4"
+ark-bls12-381 = { workspace = true }


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
- Deduplicates where needed and moves dependencies to `./Cargo.toml`
- Generated with [`cargo autoinherit`](https://mainmatter.com/blog/2024/03/18/cargo-autoinherit/)

**Why it's needed:**
- Prevents conflicting child dependency version, a source of confusion when debugging conflicts with `cargo tree`
